### PR TITLE
Add heading error with explanation on how to fix it

### DIFF
--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/MermaidGraph.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/MermaidGraph.kt
@@ -105,9 +105,10 @@ fun appendMermaidGraphToReadme(
             In order to decide where in the README file the flowchart should be generated, there must be a section
             inside the README file which matches the text provided in `heading` property inside your
             `moduleGraphConfig {}` block.
-            Suggested change: add the following text at the end of your README file ${readmeFile.path}
-
-            $readMeSection
+            Suggested change:
+            Add the section "$readMeSection" inside of your README file.
+            or
+            Change `heading.set("$readMeSection")` to a string which already exists inside your README file.
             """.trimIndent()
         )
     }

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/MermaidGraph.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/MermaidGraph.kt
@@ -99,7 +99,17 @@ fun appendMermaidGraphToReadme(
         readmeFile.writeText(readmeLines.joinToString("\n"))
         logger.debug("Module graph added to ${readmeFile.path} under the $readMeSection section")
     } else {
-        logger.debug("The $readMeSection section was not found in ${readmeFile.path}")
+        logger.error(
+            """
+            The "$readMeSection" section was not found in ${readmeFile.path}
+            In order to decide where in the README file the flowchart should be generated, there must be a section
+            inside the README file which matches the text provided in `heading` property inside your
+            `moduleGraphConfig {}` block.
+            Suggested change: add the following text at the end of your README file ${readmeFile.path}
+
+            $readMeSection
+            """.trimIndent()
+        )
     }
 }
 


### PR DESCRIPTION
## 🚀 Description
For cases where the heading is not set properly, the plugin will give a detailed explanation of what goes wrong and how to fix it.
Addresses #1 

You may want to edit the text provided and/or even add the groovy syntax describing how to fix the issue if you wish. For the text itself I think this should suffice but definitely feel free to suggest a better error message if you wish.

## 📄 Motivation and Context
See #1

## 🧪 How Has This Been Tested?
Inside `module-graph/sample/build.gradle.kts`, edit the `moduleGraphConfig` block and make a typo in the `heading.set` to be `heading.set("### Dependency Diagrm")` instead of `heading.set("### Dependency Diagram").
Then run `./gradlew :sample:createModuleGraph`
Then you get a gradle error with the following message:

<img width="986" alt="image" src="https://user-images.githubusercontent.com/44558292/229092391-98f9a4df-7f07-4b42-bc19-d328a4d93ce5.png">

## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.