### PR TITLE
Add `createReadmeIfMissing` setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ apply plugin: "dev.iurysouza.modulegraph"
     theme = Theme.NEUTRAL // optional
     orientation = Orientation.LEFT_TO_RIGHT // optional
     linkText = LinkText.CONFIGURATION // optional
+    createReadmeIfMissing = true // optional
 }
 ```
 
@@ -107,6 +108,7 @@ moduleGraphConfig {
     theme.set(Theme.NEUTRAL) // optional
     orientation.set(Orientation.LEFT_TO_RIGHT) //optional
     linkText.set(LinkText.CONFIGURATION) // optional
+    createReadmeIfMissing.set(true) // optional
 }
 ```
 
@@ -130,6 +132,8 @@ Optional settings:
   Whether to add information as text on links in graph. Available values:
   - `NONE`: No text added. (Default.)
   - `CONFIGURATION`: The name of the configuration which the dependency belongs to (e.g. "implementation", "compileOnly", "jsMain").
+- **createReadmeIfMissing**:
+  Create the specified `readmePath` if it does not exist. Default is `false`.
 
 ## Usage
 

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/CreateModuleGraphTask.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/CreateModuleGraphTask.kt
@@ -28,6 +28,14 @@ abstract class CreateModuleGraphTask : DefaultTask() {
     abstract val readmePath: Property<String>
 
     @get:Input
+    @get:Option(
+        option = "createReadmeIfMissing",
+        description = "Create readme file instead of failing the task if the file is missing."
+    )
+    @get:Optional
+    abstract val createReadmeIfMissing: Property<Boolean>
+
+    @get:Input
     @get:Option(option = "theme", description = "The mermaid theme")
     @get:Optional
     abstract val theme: Property<Theme>
@@ -67,7 +75,13 @@ abstract class CreateModuleGraphTask : DefaultTask() {
                 linkText = linkText.getOrElse(LinkText.NONE),
                 dependencies = dependencies.get()
             )
-            appendMermaidGraphToReadme(mermaidGraph, heading.get(), outputFile.get().asFile, logger)
+            appendMermaidGraphToReadme(
+                mermaidGraph = mermaidGraph,
+                readMeSection = heading.get(),
+                readmeFile = outputFile.get().asFile,
+                createReadmeIfMissing = createReadmeIfMissing.getOrElse(false),
+                logger = logger
+            )
         } catch (e: Exception) {
             logger.log(LogLevel.ERROR, e.message, e)
         }

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/MermaidGraph.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/MermaidGraph.kt
@@ -90,10 +90,19 @@ fun appendMermaidGraphToReadme(
     mermaidGraph: String,
     readMeSection: String,
     readmeFile: File,
+    createReadmeIfMissing: Boolean,
     logger: Logger,
 ) {
+    if (createReadmeIfMissing && !readmeFile.exists()) {
+        readmeFile.createNewFile()
+        logger.warn(
+            """
+            The specified readme file does not exist: ${readmeFile.path}.
+            The file has been created.
+            """.trimIndent()
+        )
+    }
     val readmeLines: MutableList<String> = readmeFile.readLines().toMutableList()
-
     val modulesIndex = readmeLines.indexOfFirst { it.startsWith(readMeSection) }
 
     if (modulesIndex != -1) {

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/ModuleGraphExtension.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/ModuleGraphExtension.kt
@@ -15,6 +15,8 @@ abstract class ModuleGraphExtension @Inject constructor(project: Project) {
 
     val readmePath: Property<String> = objects.property(String::class.java)
 
+    val createReadmeIfMissing: Property<Boolean> = objects.property(Boolean::class.java)
+
     val heading: Property<String> = objects.property(String::class.java)
 
     val linkText: Property<LinkText> = objects.property(LinkText::class.java)

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/ModuleGraphPlugin.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/ModuleGraphPlugin.kt
@@ -20,6 +20,7 @@ abstract class ModuleGraphPlugin : Plugin<Project> {
         ) { task ->
             task.heading.set(extension.heading)
             task.readmePath.set(extension.readmePath)
+            task.createReadmeIfMissing.set(extension.createReadmeIfMissing)
             task.theme.set(extension.theme)
             task.orientation.set(extension.orientation)
             task.linkText.set(extension.linkText)

--- a/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/ModuleGraphPluginTest.kt
+++ b/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/ModuleGraphPluginTest.kt
@@ -34,12 +34,14 @@ class ModuleGraphPluginTest {
             theme.set(Theme.NEUTRAL)
             orientation.set(Orientation.TOP_TO_BOTTOM)
             readmePath.set(aFilePath)
+            createReadmeIfMissing.set(true)
         }
 
         val task = project.tasks.getByName("createModuleGraph") as CreateModuleGraphTask
 
         assertEquals("### Dependency Diagram", task.heading.get())
         assertEquals(aFilePath, task.readmePath.get())
+        assertEquals(true, task.createReadmeIfMissing.get())
         assertEquals(Theme.NEUTRAL, task.theme.get())
         assertEquals(Orientation.TOP_TO_BOTTOM, task.orientation.get())
     }


### PR DESCRIPTION
## 🚀 Description
Added a new setting `createReadmeIfMissing` (defaults to `false`) which creates the specified `readmePath` if it does not exist.

## 📄 Motivation and Context
Fixes iurysza/module-graph#11.

## 🧪 How Has This Been Tested?
Tested through unit tests.

## 📦 Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.