### PR TITLE
Add filtering option for excluding specific configuration name

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Optional settings:
     - `CONFIGURATION`: The name of the configuration which the dependency belongs to (e.g. "
       implementation", "compileOnly", "jsMain").
 - **excludeConfigurationNames**:
-  - List of configuration name which should be ignored. e.g. "implementation", "testImplementation". Default is emptyList().
+  - List of configuration names which should be ignored. e.g. "implementation", "testImplementation". Default is emptyList().
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ Optional settings:
     - `NONE`: No text added. (Default.)
     - `CONFIGURATION`: The name of the configuration which the dependency belongs to (e.g. "
       implementation", "compileOnly", "jsMain").
+- **excludeConfigurationNames**:
+  - List of configuration name which should be ignored. e.g. "implementation", "testImplementation". Default is emptyList().
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ moduleGraphConfig {
     //      )
     //   )
     // )
+    excludeConfigurationNames.set( // optional
+        listOf("testImplementation")
+    )
 }
 ```
 

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/CreateModuleGraphTask.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/CreateModuleGraphTask.kt
@@ -49,7 +49,7 @@ abstract class CreateModuleGraphTask : DefaultTask() {
     abstract val linkText: Property<LinkText>
 
     @get:Input
-    @get:Option(option = "excludeConfigurationNames", description = "List of configuration name which should be ignored")
+    @get:Option(option = "excludeConfigurationNames", description = "List of configuration names to be ignored")
     @get:Optional
     abstract val excludeConfigurationNames: ListProperty<String>
 

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/CreateModuleGraphTask.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/CreateModuleGraphTask.kt
@@ -9,6 +9,7 @@ import dev.iurysouza.modulegraph.buildMermaidGraph
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.logging.LogLevel
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
@@ -46,6 +47,11 @@ abstract class CreateModuleGraphTask : DefaultTask() {
     @get:Option(option = "linkText", description = "Whether to add information as text on links in graph")
     @get:Optional
     abstract val linkText: Property<LinkText>
+
+    @get:Input
+    @get:Option(option = "excludeConfigurationNames", description = "List of configuration name which should be ignored")
+    @get:Optional
+    abstract val excludeConfigurationNames: ListProperty<String>
 
     @get:Input
     @get:Option(option = "dependencies", description = "The project dependencies")

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/ModuleGraphExtension.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/ModuleGraphExtension.kt
@@ -5,6 +5,7 @@ import dev.iurysouza.modulegraph.Orientation
 import dev.iurysouza.modulegraph.Theme
 import javax.inject.Inject
 import org.gradle.api.Project
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 
 /**
@@ -43,6 +44,13 @@ open class ModuleGraphExtension @Inject constructor(project: Project) {
      * This is an optional input. Defaults to [LinkText.NONE].
      */
     val linkText: Property<LinkText> = objects.property(LinkText::class.java)
+
+    /**
+     * List of configuration name which should be ignored.
+     * e.g. "implementation", "testImplementation" will be set.
+     * This is an optional input. Defaults to [emptyList].
+     */
+    val excludeConfigurationNames: ListProperty<String> = objects.listProperty(String::class.java)
 
     /**
      * Whether to show the full path of the module in the graph.

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/ModuleGraphExtension.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/ModuleGraphExtension.kt
@@ -46,7 +46,7 @@ open class ModuleGraphExtension @Inject constructor(project: Project) {
     val linkText: Property<LinkText> = objects.property(LinkText::class.java)
 
     /**
-     * List of configuration name which should be ignored.
+     * List of configuration names to be ignored.
      * e.g. "implementation", "testImplementation" will be set.
      * This is an optional input. Defaults to [emptyList].
      */

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/ModuleGraphPlugin.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/ModuleGraphPlugin.kt
@@ -25,7 +25,9 @@ open class ModuleGraphPlugin : Plugin<Project> {
             task.linkText.set(extension.linkText)
             task.showFullPath.set(extension.showFullPath)
 
-            task.dependencies.set(project.parseProjectStructure())
+            task.dependencies.set(project.parseProjectStructure(
+                extension.excludeConfigurationNames.getOrElse(emptyList()))
+            )
             task.outputFile.set(project.layout.projectDirectory.file(extension.readmePath))
         }
     }

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/ProjectParser.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/ProjectParser.kt
@@ -4,16 +4,18 @@ import dev.iurysouza.modulegraph.Dependency
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ProjectDependency
 
-internal fun Project.parseProjectStructure(): HashMap<String, List<Dependency>> {
+internal fun Project.parseProjectStructure(excludeConfigurationNames: List<String>): HashMap<String, List<Dependency>> {
     val dependencies = hashMapOf<String, List<Dependency>>()
     project.allprojects.forEach { sourceProject ->
         sourceProject.configurations.forEach { config ->
             config.dependencies.withType(ProjectDependency::class.java)
                 .map { it.dependencyProject }
                 .forEach { targetProject ->
-                    dependencies[sourceProject.path] =
-                        dependencies.getOrDefault(sourceProject.path, emptyList())
-                            .plus(Dependency(targetProject.path, config.name))
+                    if(!excludeConfigurationNames.contains(config.name)) {
+                        dependencies[sourceProject.path] =
+                            dependencies.getOrDefault(sourceProject.path, emptyList())
+                                .plus(Dependency(targetProject.path, config.name))
+                    }
                 }
         }
     }

--- a/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/ModuleGraphPluginTest.kt
+++ b/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/ModuleGraphPluginTest.kt
@@ -31,6 +31,7 @@ class ModuleGraphPluginTest {
         val project = ProjectBuilder.builder().build()
         project.pluginManager.apply(pluginId)
         val aFilePath = "${project.projectDir}/README.md"
+        val aExcludeConfigurationNames = listOf("implementation")
         (project.extensions.getByName(pluginExtension) as ModuleGraphExtension).apply {
             heading.set("### Dependency Diagram")
             theme.set(Theme.NEUTRAL)
@@ -38,6 +39,7 @@ class ModuleGraphPluginTest {
             linkText.set(LinkText.CONFIGURATION)
             orientation.set(Orientation.TOP_TO_BOTTOM)
             readmePath.set(aFilePath)
+            excludeConfigurationNames.set(aExcludeConfigurationNames)
         }
 
         val task = project.tasks.getByName("createModuleGraph") as CreateModuleGraphTask
@@ -48,5 +50,6 @@ class ModuleGraphPluginTest {
         assertEquals(true, task.showFullPath.get())
         assertEquals(Theme.NEUTRAL, task.theme.get())
         assertEquals(Orientation.TOP_TO_BOTTOM, task.orientation.get())
+        assertEquals(aExcludeConfigurationNames, task.excludeConfigurationNames.get())
     }
 }

--- a/sample/alpha/build.gradle.kts
+++ b/sample/alpha/build.gradle.kts
@@ -7,4 +7,6 @@ dependencies {
     implementation(project(":sample:beta"))
     implementation(project(":sample:container:gama"))
     implementation(project(":sample:container:delta"))
+
+    testImplementation(project(":sample:test"))
 }

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -26,6 +26,7 @@ moduleGraphConfig {
             )
         )
     )
+    excludeConfigurationNames.set(listOf("testImplementation"))
 }
 
 task("check") {

--- a/sample/test/build.gradle.kts
+++ b/sample/test/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    java
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -31,6 +31,7 @@ rootProject.name = "module-graph-plugin-project"
 include(":sample:alpha")
 include(":sample:beta")
 include(":sample:zeta")
+include(":sample:test")
 include(":sample:container:gama")
 include(":sample:container:delta")
 includeBuild("plugin-build")


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
Try to add `excludeConfigurationNames` option which you can ignore specific configuration names.

Fix https://github.com/iurysza/module-graph/issues/21 

example usage is below

```
moduleGraphConfig {
    heading.set("# Module Graph")
    readmePath.set("./README.md")

    // optional configs
    excludeConfigurationNames.set(listOf("testImplementation"))
}
```

## 📄 Motivation and Context
I have same situation as https://github.com/iurysza/module-graph/issues/21 .
I know @iurysza is writing POC with Regex seeing https://github.com/iurysza/module-graph/tree/regex-filter .
However as https://github.com/iurysza/module-graph/issues/21 stated, I think there is a major case that want to ignore specific configuration (especially `testImplementation` ) for document use. 

I'm open to discuss about this feature so just let me know your opinion.

## 🧪 How Has This Been Tested?
Added some test cases for `ModuleGraphPluginFunctionalTest` 
And also tested with sample project.

## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.