### PR TITLE
Add support for excluding modules

### DIFF
--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/CreateModuleGraphTask.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/CreateModuleGraphTask.kt
@@ -4,7 +4,6 @@ import dev.iurysouza.modulegraph.*
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.logging.LogLevel
-import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
@@ -49,9 +48,17 @@ abstract class CreateModuleGraphTask : DefaultTask() {
     abstract val linkText: Property<LinkText>
 
     @get:Input
-    @get:Option(option = "excludeConfigurationNames", description = "List of configuration names to be ignored")
+    @get:Option(
+        option = "excludedConfigurationsRegex",
+        description = "A Regex to match configurations that should removed",
+    )
     @get:Optional
-    abstract val excludeConfigurationNames: ListProperty<String>
+    abstract val excludedConfigurationsRegex: Property<String>
+
+    @get:Input
+    @get:Option(option = "excludedModulesRegex", description = "A Regex to match nodes that should removed")
+    @get:Optional
+    abstract val excludedModulesRegex: Property<String>
 
     @get:Input
     @get:Option(option = "dependencies", description = "The project dependencies")

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/ModuleGraphExtension.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/ModuleGraphExtension.kt
@@ -5,7 +5,6 @@ import dev.iurysouza.modulegraph.Orientation
 import dev.iurysouza.modulegraph.Theme
 import javax.inject.Inject
 import org.gradle.api.Project
-import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 
 /**
@@ -54,11 +53,14 @@ open class ModuleGraphExtension @Inject constructor(project: Project) {
     val linkText: Property<LinkText> = objects.property(LinkText::class.java)
 
     /**
-     * List of configuration names to be ignored.
-     * e.g. "implementation", "testImplementation" will be set.
-     * This is an optional input. Defaults to [emptyList].
+     * A Regex to match configurations that should be ignored.
      */
-    val excludeConfigurationNames: ListProperty<String> = objects.listProperty(String::class.java)
+    val excludedConfigurationsRegex: Property<String> = objects.property(String::class.java)
+
+    /**
+     * A Regex to match modules that should be excluded from the graph.
+     */
+    val excludedModulesRegex: Property<String> = objects.property(String::class.java)
 
     /**
      * Whether to show the full path of the module in the graph.

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/ModuleGraphPlugin.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/ModuleGraphPlugin.kt
@@ -25,9 +25,13 @@ open class ModuleGraphPlugin : Plugin<Project> {
             task.orientation.set(extension.orientation)
             task.linkText.set(extension.linkText)
             task.showFullPath.set(extension.showFullPath)
-            task.excludeConfigurationNames.set(extension.excludeConfigurationNames)
+            task.excludedConfigurationsRegex.set(extension.excludedConfigurationsRegex)
+            task.excludedModulesRegex.set(extension.excludedModulesRegex)
             task.dependencies.set(
-                project.parseProjectStructure(setOf(ExclusionStrategy.Project("match-day"), ExclusionStrategy.Configuration(".*(debug).*"))),
+                project.parseProjectStructure(
+                    extension.excludedConfigurationsRegex.orNull,
+                    extension.excludedModulesRegex.orNull,
+                ),
             )
             task.outputFile.set(project.layout.projectDirectory.file(extension.readmePath))
         }

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/ModuleGraphPlugin.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/ModuleGraphPlugin.kt
@@ -27,7 +27,7 @@ open class ModuleGraphPlugin : Plugin<Project> {
             task.showFullPath.set(extension.showFullPath)
             task.excludeConfigurationNames.set(extension.excludeConfigurationNames)
             task.dependencies.set(
-                project.parseProjectStructure(extension.excludeConfigurationNames.getOrElse(emptyList())),
+                project.parseProjectStructure(setOf(ExclusionStrategy.Project("match-day"), ExclusionStrategy.Configuration(".*(debug).*"))),
             )
             task.outputFile.set(project.layout.projectDirectory.file(extension.readmePath))
         }

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/ProjectParser.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/ProjectParser.kt
@@ -2,22 +2,44 @@ package dev.iurysouza.modulegraph.gradle
 
 import dev.iurysouza.modulegraph.Dependency
 import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ProjectDependency
 
-internal fun Project.parseProjectStructure(excludeConfigurationNames: List<String>): HashMap<String, List<Dependency>> {
+internal fun Project.parseProjectStructure(
+    exclusionStrategy: Set<ExclusionStrategy> = emptySet(),
+): HashMap<String, List<Dependency>> {
     val dependencies = hashMapOf<String, List<Dependency>>()
-    project.allprojects.forEach { sourceProject ->
-        sourceProject.configurations.forEach { config ->
-            config.dependencies.withType(ProjectDependency::class.java)
-                .map { it.dependencyProject }
-                .forEach { targetProject ->
-                    if (!excludeConfigurationNames.contains(config.name)) {
-                        dependencies[sourceProject.path] =
-                            dependencies.getOrDefault(sourceProject.path, emptyList())
-                                .plus(Dependency(targetProject.path, config.name))
-                    }
+    project.allprojects
+        .asSequence()
+        .filter { project -> exclusionStrategy.projectMatches(project) }
+        .forEach { sourceProject ->
+            sourceProject.configurations
+                .asSequence()
+                .forEach { config ->
+                    config.dependencies.withType(ProjectDependency::class.java)
+                        .map { it.dependencyProject }
+                        .filter { exclusionStrategy.projectMatches(it) }
+                        .filter { exclusionStrategy.configurationMatches(config) }
+                        .forEach { targetProject ->
+                            dependencies[sourceProject.path] =
+                                dependencies.getOrDefault(sourceProject.path, emptyList())
+                                    .plus(Dependency(targetProject.path, config.name))
+                        }
                 }
         }
-    }
     return dependencies
+}
+
+private fun Set<ExclusionStrategy>.configurationMatches(
+    configuration: Configuration,
+) = filterIsInstance<ExclusionStrategy.Configuration>().none { it.pattern.toRegex().matches(configuration.name) }
+
+private fun Set<ExclusionStrategy>.projectMatches(
+    project: Project,
+) = filterIsInstance<ExclusionStrategy.Project>().none { it.pattern.toRegex().matches(project.name) }
+
+
+sealed class ExclusionStrategy(open val pattern: String) {
+    data class Project(override val pattern: String) : ExclusionStrategy(pattern)
+    data class Configuration(override val pattern: String) : ExclusionStrategy(pattern)
 }

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/graph/SubgraphBuilder.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/graph/SubgraphBuilder.kt
@@ -8,9 +8,8 @@ internal object SubgraphBuilder {
      * @param list The list of digraph models to be grouped by parent.
      * @return The resulting `MermaidCode` corresponding to the structured digraphs.
      *
-     * Example usage:
-     *```mermaid
-     *graph TB
+     * eg.:
+     *```
      *  subgraph sample
      *    alpha
      *    zeta
@@ -28,24 +27,25 @@ internal object SubgraphBuilder {
         return toMermaidCode(subGraphs)
     }
 
-    private fun toMermaidCode(subgraphModel: List<Pair<String, List<ModuleNode>>>): MermaidCode {
-        val subgraph = subgraphModel.joinToString("\n") { (parent, children) ->
-            if (parent.isEmpty()) return@joinToString ""
+    private fun toMermaidCode(
+        subgraphModel: List<Pair<String, List<ModuleNode>>>,
+    ): MermaidCode = MermaidCode(
+        subgraphModel.joinToString("\n") { (parent, children) ->
             val childrenNames = children.joinToString("\n") { "    ${it.name}" }
             """|  subgraph $parent
                |$childrenNames
                |  end
             """.trimMargin()
-        }
-
-        return MermaidCode(subgraph.trimMargin())
-    }
+        }.trimMargin(),
+    )
 
     private fun groupDigraphsByParent(
         modelList: List<DigraphModel>,
-    ): List<Pair<String, List<ModuleNode>>> = modelList
+    ): List<Pair<String, List<ModuleNode>>> = modelList.asSequence()
         .flatMap { listOf(it.source, it.target) }
+        .filter { it.parent.isNotEmpty() }
         .groupBy { it.parent }
         .map { (parent, children) -> parent to children.distinctBy { it.name } }
         .sortedBy { it.first }
+        .toList()
 }

--- a/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/ModuleGraphPluginFunctionalTest.kt
+++ b/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/ModuleGraphPluginFunctionalTest.kt
@@ -341,7 +341,8 @@ class ModuleGraphPluginFunctionalTest {
                     theme.set($MODULEGRAPH_PACKAGE.Theme.FOREST)
                     orientation.set($MODULEGRAPH_PACKAGE.Orientation.RIGHT_TO_LEFT)
                     readmePath.set("${readmeFilePath()}")
-                    excludeConfigurationNames.set(listOf("testImplementation"))
+                    excludedModulesRegex.set("project")
+                    excludedConfigurationsRegex.set("testImplementation")
                 }
                 dependencies {
                     implementation(project(":groupFolder:example2"))

--- a/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/ModuleGraphPluginTest.kt
+++ b/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/ModuleGraphPluginTest.kt
@@ -32,7 +32,6 @@ class ModuleGraphPluginTest {
         project.pluginManager.apply(pluginId)
         val aFilePath = "${project.projectDir}/README.md"
         val aRegexPattern = ".*"
-        val aExcludeConfigurationNames = listOf("implementation")
         (project.extensions.getByName(pluginExtension) as ModuleGraphExtension).apply {
             heading.set("### Dependency Diagram")
             theme.set(Theme.NEUTRAL)
@@ -41,7 +40,8 @@ class ModuleGraphPluginTest {
             focusedNodesPattern.set(aRegexPattern)
             orientation.set(Orientation.TOP_TO_BOTTOM)
             readmePath.set(aFilePath)
-            excludeConfigurationNames.set(aExcludeConfigurationNames)
+            excludedConfigurationsRegex.set("implementation")
+            excludedModulesRegex.set("project")
         }
 
         val task = project.tasks.getByName("createModuleGraph") as CreateModuleGraphTask
@@ -53,6 +53,7 @@ class ModuleGraphPluginTest {
         assertEquals(Theme.NEUTRAL, task.theme.get())
         assertEquals(Orientation.TOP_TO_BOTTOM, task.orientation.get())
         assertEquals(aRegexPattern, task.focusedNodesPattern.get())
-        assertEquals(aExcludeConfigurationNames, task.excludeConfigurationNames.get())
+        assertEquals("implementation", task.excludedConfigurationsRegex.get())
+        assertEquals("project", task.excludedModulesRegex.get())
     }
 }

--- a/sample/README.md
+++ b/sample/README.md
@@ -13,10 +13,8 @@ graph TB
     gama
   end
   subgraph sample
-    alpha
     zeta
   end
-  alpha --> gama
   gama --> zeta
 
 classDef focus fill:#F5A622,stroke:#fff,stroke-width:2px,color:#fff;

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -28,7 +28,8 @@ moduleGraphConfig {
             focusColor = "#F5A622",
         ),
     )
-    excludeConfigurationNames.set(listOf("testImplementation"))
+    excludedConfigurationsRegex.set(""".*test.*""")
+    excludedModulesRegex.set(".*alpha.*")
 }
 
 task("check") {


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
Refactored configuration exclusion logic to use regex patterns. The exclusion mechanism now supports multiple exclusion criteria.

## 📄 Motivation and Context

This change addresses the need for a more powerful exclusion mechanism as per user feedback.
Resolves #16 

## 🧪 How Has This Been Tested?
-  Unit tests were updated to reflect the new exclusion logic
-  Manual testing in a multi-module project to verify that the regex-based exclusions correctly omit specified configurations and modules from the graph.

## 📦 Types of changes
-  [ ] Bug fix (non-breaking change which fixes an issue)
-  [ ] New feature (non-breaking change which adds functionality)
-  [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
-  [x] My code follows the code style of this project.
-  [x] My change requires a change to the documentation.
-  [x] I have updated the documentation accordingly.
