### PR TITLE
Fully qualify module names

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ moduleGraphConfig {
     excludedConfigurationsRegex = ".*test.*" // optional
     excludedModulesRegex = ".*moduleName.*" // optional
     focusedModulesRegex = ".*(projectName).*" // optional
+    setStyleByPluginType = true // optional
     theme = Theme.NEUTRAL // optional
     // Or you can fully customize it by using the BASE theme:
     // theme = new Theme.BASE(
@@ -165,6 +166,7 @@ moduleGraphConfig {
     showFullPath.set(false) // optional
     orientation.set(Orientation.LEFT_TO_RIGHT) //optional
     linkText.set(LinkText.NONE) // optional
+    setStyleByPluginType.set(true) // optional
     excludedConfigurationsRegex.set(".*test.*") // optional
     excludedModulesRegex.set(".*moduleName.*") // optional
     focusedModulesRegex.set(".*(projectName).*") // optional
@@ -212,13 +214,12 @@ Required settings:
 
 Optional settings:
 
+- **setStyleByPluginType**: Whether to style the modules based on their type (KotlinMultiplatform, Android Library, etc). Default is `false`. [Read more](#module-type-based-styling).
 - **focusedModulesRegex**: The Pattern (Regex) to match nodes in the graph (project names) that should be focused. By
   default, no nodes are focused.
   If set, the matching nodes will be highlighted. The color can be customized via the `focusColor` property
   from `Theme.BASE`. [Read more](#focusing-on-specific-nodes).
-- **showFullPath**: Whether to show the full path of the modules in the graph. Default is `false`. **Use this if you
-  have
-  **modules with the same name in different paths**. This will remove the subgraphs from the graph.
+- **showFullPath**: Whether to show the full path of the modules in the graph. Default is `false`. This removes subgraphs.
 - **theme**: The [mermaid theme](https://mermaid.js.org/config/theming.html) to be used for styling
   the graph. Default is `NEUTRAL`.
     - Further customization is possible by setting the `themeVariables` property on the `BASE` theme. Check the

--- a/README.md
+++ b/README.md
@@ -215,9 +215,9 @@ Required settings:
 Optional settings:
 
 - **setStyleByPluginType**: Whether to style the modules based on their type (KotlinMultiplatform, Android Library, etc). Default is `false`. [Read more](#module-type-based-styling).
-- **focusedModulesRegex**: The Pattern (Regex) to match nodes in the graph (project names) that should be focused. By
+- **focusedModulesRegex**: The regex to match nodes in the graph (project names) that should be focused. By
   default, no nodes are focused.
-  If set, the matching nodes will be highlighted. The color can be customized via the `focusColor` property
+  If set, the matching nodes will be highlighted and only related nodes will be shown. The color can be customized via the `focusColor` property
   from `Theme.BASE`. [Read more](#focusing-on-specific-nodes).
 - **showFullPath**: Whether to show the full path of the modules in the graph. Default is `false`. This removes subgraphs.
 - **theme**: The [mermaid theme](https://mermaid.js.org/config/theming.html) to be used for styling
@@ -417,9 +417,9 @@ That's it. Just run the task and you'll get a graph identifying modules by their
 
 We have default styling for these module types:
 
+- Android Application
 - React Native
 - Kotlin Multiplatform
-- Android Application
 - Android Library
 - Kotlin
 - Java Library

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/ModuleType.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/ModuleType.kt
@@ -102,9 +102,9 @@ internal fun Project.hasLibraryDependency(dependencyGroupAndName: String): Boole
 
 internal val pluginPrecedenceOrder = listOf(
     ModuleType.Custom::class,
+    ModuleType.AndroidApp::class,
     ModuleType.ReactNativeLibrary::class,
     ModuleType.KotlinMultiplatform::class,
-    ModuleType.AndroidApp::class,
     ModuleType.AndroidLibrary::class,
     ModuleType.Kotlin::class,
     ModuleType.JavaLibrary::class,

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/graph/DigraphBuilder.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/graph/DigraphBuilder.kt
@@ -87,8 +87,7 @@ internal object DigraphBuilder {
         val groups = split(":")
         if (groups.size == 1) return ""
         return groups
-            .takeLast(2)
-            .take(1)
-            .joinToString("")
+            .dropLast(1)
+            .joinToString(":")
     }
 }

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/graph/DigraphCodeBuilder.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/graph/DigraphCodeBuilder.kt
@@ -28,7 +28,7 @@ internal object DigraphCodeBuilder {
     )
 
     private fun toMermaid(it: DigraphModel, linkText: LinkText): CharSequence = """
-        |  ${it.source.name} ${linkText.toLinkString(it.target.config.value)} ${it.target.name}
+        |  ${it.source.fullName} ${linkText.toLinkString(it.target.config.value)} ${it.target.fullName}
     """.trimMargin()
 }
 

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/graph/NodeStyleBuilder.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/graph/NodeStyleBuilder.kt
@@ -26,7 +26,7 @@ internal object NodeStyleBuilder {
     fun build(digraphModel: List<DigraphModel>, options: GraphOptions): MermaidCode {
         val distinctNodes = digraphModel
             .flatMap { listOf(it.source, it.target) }
-            .distinctBy { it.name }
+            .distinctBy { it.fullName }
         val focusedNodes = distinctNodes.filter { it.isFocused }
 
         val pluginTypeStyling = applyStylingByPluginType(options, distinctNodes)
@@ -57,7 +57,7 @@ internal object NodeStyleBuilder {
             }
             """.trimMargin() + """
                 |
-                |${nodeList.joinToString("\n") { "class ${it.name} ${it.pluginClass()}" }}
+                |${nodeList.joinToString("\n") { "class ${it.fullName} ${it.pluginClass()}" }}
             """.trimMargin()
         } else {
             ""
@@ -82,7 +82,7 @@ internal object NodeStyleBuilder {
             """
                |
                |${defineStyleClass(FOCUS_CLASS_NAME, theme.focusColor())}
-               |${nodeList.joinToString("\n") { "class ${it.name} $FOCUS_CLASS_NAME" }}
+               |${nodeList.joinToString("\n") { "class ${it.fullName} $FOCUS_CLASS_NAME" }}
             """.trimMargin()
         },
     )

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/graph/SubgraphBuilder.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/graph/SubgraphBuilder.kt
@@ -31,7 +31,7 @@ internal object SubgraphBuilder {
         subgraphModel: List<Pair<String, List<ModuleNode>>>,
     ): MermaidCode = MermaidCode(
         subgraphModel.joinToString("\n") { (parent, children) ->
-            val childrenNames = children.joinToString("\n") { "    ${it.name}" }
+            val childrenNames = children.joinToString("\n") { """    ${it.fullName}["${it.name}"]""" }
             """|  subgraph $parent
                |$childrenNames
                |  end
@@ -45,7 +45,7 @@ internal object SubgraphBuilder {
         .flatMap { listOf(it.source, it.target) }
         .filter { it.parent.isNotEmpty() }
         .groupBy { it.parent }
-        .map { (parent, children) -> parent to children.distinctBy { it.name } }
+        .map { (parent, children) -> parent to children.distinctBy { it.fullName } }
         .sortedBy { it.first }
         .toList()
 }

--- a/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/ModuleGraphPluginFunctionalTest.kt
+++ b/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/ModuleGraphPluginFunctionalTest.kt
@@ -83,10 +83,10 @@ class ModuleGraphPluginFunctionalTest {
                 }%%
 
                 graph RL
-                  subgraph groupFolder
-                    example2
+                  subgraph :groupFolder
+                    :groupFolder:example2["example2"]
                   end
-                  example --> example2
+                  :example --> :groupFolder:example2
                 ```
             """.trimIndent()
         assertEquals(expectedOutput, readmeFile.readText())
@@ -151,10 +151,10 @@ class ModuleGraphPluginFunctionalTest {
                 }%%
 
                 graph LR
-                  subgraph groupFolder
-                    example2
+                  subgraph :groupFolder
+                    :groupFolder:example2["example2"]
                   end
-                  example --> example2
+                  :example --> :groupFolder:example2
                 ```
             """.trimIndent()
         assertEquals(expectedOutput, readmeFile.readText())
@@ -267,12 +267,12 @@ class ModuleGraphPluginFunctionalTest {
                 }%%
 
                 graph RL
-                  subgraph groupFolder
-                    example2
-                    example3
+                  subgraph :groupFolder
+                    :groupFolder:example2["example2"]
+                    :groupFolder:example3["example3"]
                   end
-                  example -- implementation --> example2
-                  example -- runtimeOnly --> example3
+                  :example -- implementation --> :groupFolder:example2
+                  :example -- runtimeOnly --> :groupFolder:example3
                 ```
             """.trimIndent()
         assertEquals(expectedOutput, readmeFile.readText())
@@ -372,10 +372,10 @@ class ModuleGraphPluginFunctionalTest {
                 }%%
 
                 graph RL
-                  subgraph groupFolder
-                    example2
+                  subgraph :groupFolder
+                    :groupFolder:example2["example2"]
                   end
-                  example --> example2
+                  :example --> :groupFolder:example2
                 ```
             """.trimIndent()
         assertEquals(expectedOutput, readmeFile.readText())

--- a/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/graph/DigraphCodeBuilderTest.kt
+++ b/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/graph/DigraphCodeBuilderTest.kt
@@ -19,8 +19,8 @@ class DigraphCodeBuilderTest {
         )
 
         val expectedMermaidCode = """
-        |  alpha --> gama
-        |  gama --> zeta
+        |  :sample:alpha --> :sample:container:gama
+        |  :sample:container:gama --> :sample:zeta
         """.trimMargin()
         assertEquals(expectedMermaidCode, mermaidCode.value)
     }
@@ -51,26 +51,26 @@ class DigraphCodeBuilderTest {
         )
 
         val expectedMermaidCode = """
-                |  footballinfo --> common
-                |  match-day --> common
-                |  match-day --> footballinfo
-                |  match-day --> design-system
-                |  match-day --> reddit
-                |  match-thread --> webview-to-native-player
-                |  match-thread --> common
-                |  match-thread --> footballinfo
-                |  match-thread --> design-system
-                |  match-thread --> reddit
-                |  playground --> webview-to-native-player
-                |  playground --> match-thread
-                |  playground --> design-system
-                |  playground --> match-day
-                |  reddit --> common
-                |  webview-to-native-player --> common
-                |  main --> match-thread
-                |  main --> match-day
-                |  main --> design-system
-                |  main --> common
+            |  :core:footballinfo --> :core:common
+            |  :features:match-day --> :core:common
+            |  :features:match-day --> :core:footballinfo
+            |  :features:match-day --> :core:design-system
+            |  :features:match-day --> :core:reddit
+            |  :features:match-thread --> :core:webview-to-native-player
+            |  :features:match-thread --> :core:common
+            |  :features:match-thread --> :core:footballinfo
+            |  :features:match-thread --> :core:design-system
+            |  :features:match-thread --> :core:reddit
+            |  :app:playground --> :core:webview-to-native-player
+            |  :app:playground --> :features:match-thread
+            |  :app:playground --> :core:design-system
+            |  :app:playground --> :features:match-day
+            |  :core:reddit --> :core:common
+            |  :core:webview-to-native-player --> :core:common
+            |  :app:main --> :features:match-thread
+            |  :app:main --> :features:match-day
+            |  :app:main --> :core:design-system
+            |  :app:main --> :core:common
         """.trimMargin()
         assertEquals(expectedMermaidCode, mermaidCode.value)
     }

--- a/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/graph/Fixtures.kt
+++ b/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/graph/Fixtures.kt
@@ -53,18 +53,18 @@ internal val expectedMermaidGraphCode = """
         |}%%
         |
         |graph TB
-        |  subgraph container
-        |    gama
+        |  subgraph :sample
+        |    :sample:alpha["alpha"]
+        |    :sample:zeta["zeta"]
         |  end
-        |  subgraph sample
-        |    alpha
-        |    zeta
+        |  subgraph :sample:container
+        |    :sample:container:gama["gama"]
         |  end
-        |  alpha --> gama
-        |  gama --> zeta
+        |  :sample:alpha --> :sample:container:gama
+        |  :sample:container:gama --> :sample:zeta
         |
         |classDef focus fill:#F5A622,stroke:#fff,stroke-width:2px,color:#fff;
-        |class gama focus
+        |class :sample:container:gama focus
         |```
 """.trimMargin()
 
@@ -191,41 +191,41 @@ internal val expectedLiveMatchGraph = """
     |}%%
 
     |graph LR
-    |  subgraph app
-    |    playground
-    |    main
+    |  subgraph :app
+    |    :app:playground["playground"]
+    |    :app:main["main"]
     |  end
-    |  subgraph core
-    |    footballinfo
-    |    common
-    |    design-system
-    |    reddit
-    |    webview-to-native-player
+    |  subgraph :core
+    |    :core:footballinfo["footballinfo"]
+    |    :core:common["common"]
+    |    :core:design-system["design-system"]
+    |    :core:reddit["reddit"]
+    |    :core:webview-to-native-player["webview-to-native-player"]
     |  end
-    |  subgraph features
-    |    match-day
-    |    match-thread
+    |  subgraph :features
+    |    :features:match-day["match-day"]
+    |    :features:match-thread["match-thread"]
     |  end
-    |  footballinfo --> common
-    |  match-day --> common
-    |  match-day --> footballinfo
-    |  match-day --> design-system
-    |  match-day --> reddit
-    |  match-thread --> webview-to-native-player
-    |  match-thread --> common
-    |  match-thread --> footballinfo
-    |  match-thread --> design-system
-    |  match-thread --> reddit
-    |  playground --> webview-to-native-player
-    |  playground --> match-thread
-    |  playground --> design-system
-    |  playground --> match-day
-    |  reddit --> common
-    |  webview-to-native-player --> common
-    |  main --> match-thread
-    |  main --> match-day
-    |  main --> design-system
-    |  main --> common
+    |  :core:footballinfo --> :core:common
+    |  :features:match-day --> :core:common
+    |  :features:match-day --> :core:footballinfo
+    |  :features:match-day --> :core:design-system
+    |  :features:match-day --> :core:reddit
+    |  :features:match-thread --> :core:webview-to-native-player
+    |  :features:match-thread --> :core:common
+    |  :features:match-thread --> :core:footballinfo
+    |  :features:match-thread --> :core:design-system
+    |  :features:match-thread --> :core:reddit
+    |  :app:playground --> :core:webview-to-native-player
+    |  :app:playground --> :features:match-thread
+    |  :app:playground --> :core:design-system
+    |  :app:playground --> :features:match-day
+    |  :core:reddit --> :core:common
+    |  :core:webview-to-native-player --> :core:common
+    |  :app:main --> :features:match-thread
+    |  :app:main --> :features:match-day
+    |  :app:main --> :core:design-system
+    |  :app:main --> :core:common
     |```
 """.trimMargin()
 
@@ -400,78 +400,78 @@ internal val fullLiveMatchGraph = mapOf(
     ),
 )
 internal val liveMatchMermaidGraphWithConfigurations = """
-            |  footballinfo -- debugAndroidTestCompileClasspath --> common
-            |  footballinfo -- debugUnitTestCompileClasspath --> common
-            |  footballinfo -- implementation --> common
-            |  footballinfo -- releaseUnitTestCompileClasspath --> common
-            |  match-day -- debugAndroidTestCompileClasspath --> common
-            |  match-day -- debugAndroidTestCompileClasspath --> footballinfo
-            |  match-day -- debugAndroidTestCompileClasspath --> design-system
-            |  match-day -- debugAndroidTestCompileClasspath --> reddit
-            |  match-day -- debugUnitTestCompileClasspath --> common
-            |  match-day -- debugUnitTestCompileClasspath --> footballinfo
-            |  match-day -- debugUnitTestCompileClasspath --> design-system
-            |  match-day -- debugUnitTestCompileClasspath --> reddit
-            |  match-day -- implementation --> common
-            |  match-day -- implementation --> footballinfo
-            |  match-day -- implementation --> design-system
-            |  match-day -- implementation --> reddit
-            |  match-day -- releaseUnitTestCompileClasspath --> common
-            |  match-day -- releaseUnitTestCompileClasspath --> footballinfo
-            |  match-day -- releaseUnitTestCompileClasspath --> design-system
-            |  match-day -- releaseUnitTestCompileClasspath --> reddit
-            |  match-thread -- debugAndroidTestCompileClasspath --> webview-to-native-player
-            |  match-thread -- debugAndroidTestCompileClasspath --> common
-            |  match-thread -- debugAndroidTestCompileClasspath --> footballinfo
-            |  match-thread -- debugAndroidTestCompileClasspath --> design-system
-            |  match-thread -- debugAndroidTestCompileClasspath --> reddit
-            |  match-thread -- debugUnitTestCompileClasspath --> webview-to-native-player
-            |  match-thread -- debugUnitTestCompileClasspath --> common
-            |  match-thread -- debugUnitTestCompileClasspath --> footballinfo
-            |  match-thread -- debugUnitTestCompileClasspath --> design-system
-            |  match-thread -- debugUnitTestCompileClasspath --> reddit
-            |  match-thread -- implementation --> webview-to-native-player
-            |  match-thread -- implementation --> common
-            |  match-thread -- implementation --> footballinfo
-            |  match-thread -- implementation --> design-system
-            |  match-thread -- implementation --> reddit
-            |  match-thread -- releaseUnitTestCompileClasspath --> webview-to-native-player
-            |  match-thread -- releaseUnitTestCompileClasspath --> common
-            |  match-thread -- releaseUnitTestCompileClasspath --> footballinfo
-            |  match-thread -- releaseUnitTestCompileClasspath --> design-system
-            |  match-thread -- releaseUnitTestCompileClasspath --> reddit
-            |  playground -- debugAndroidTestCompileClasspath --> webview-to-native-player
-            |  playground -- debugAndroidTestCompileClasspath --> match-thread
-            |  playground -- debugAndroidTestCompileClasspath --> design-system
-            |  playground -- debugUnitTestCompileClasspath --> webview-to-native-player
-            |  playground -- debugUnitTestCompileClasspath --> match-thread
-            |  playground -- debugUnitTestCompileClasspath --> design-system
-            |  playground -- implementation --> webview-to-native-player
-            |  playground -- implementation --> match-thread
-            |  playground -- implementation --> design-system
-            |  playground -- releaseUnitTestCompileClasspath --> webview-to-native-player
-            |  playground -- releaseUnitTestCompileClasspath --> match-thread
-            |  playground -- releaseUnitTestCompileClasspath --> design-system
-            |  playground -- testImplementation --> match-day
-            |  reddit -- debugAndroidTestCompileClasspath --> common
-            |  reddit -- debugUnitTestCompileClasspath --> common
-            |  reddit -- implementation --> common
-            |  reddit -- releaseUnitTestCompileClasspath --> common
-            |  webview-to-native-player -- implementation --> common
-            |  main -- debugAndroidTestCompileClasspath --> match-thread
-            |  main -- debugAndroidTestCompileClasspath --> match-day
-            |  main -- debugAndroidTestCompileClasspath --> design-system
-            |  main -- debugAndroidTestCompileClasspath --> common
-            |  main -- debugUnitTestCompileClasspath --> match-thread
-            |  main -- debugUnitTestCompileClasspath --> match-day
-            |  main -- debugUnitTestCompileClasspath --> design-system
-            |  main -- debugUnitTestCompileClasspath --> common
-            |  main -- implementation --> match-thread
-            |  main -- implementation --> match-day
-            |  main -- implementation --> design-system
-            |  main -- implementation --> common
-            |  main -- releaseUnitTestCompileClasspath --> match-thread
-            |  main -- releaseUnitTestCompileClasspath --> match-day
-            |  main -- releaseUnitTestCompileClasspath --> design-system
-            |  main -- releaseUnitTestCompileClasspath --> common
+|  :core:footballinfo -- debugAndroidTestCompileClasspath --> :core:common
+|  :core:footballinfo -- debugUnitTestCompileClasspath --> :core:common
+|  :core:footballinfo -- implementation --> :core:common
+|  :core:footballinfo -- releaseUnitTestCompileClasspath --> :core:common
+|  :features:match-day -- debugAndroidTestCompileClasspath --> :core:common
+|  :features:match-day -- debugAndroidTestCompileClasspath --> :core:footballinfo
+|  :features:match-day -- debugAndroidTestCompileClasspath --> :core:design-system
+|  :features:match-day -- debugAndroidTestCompileClasspath --> :core:reddit
+|  :features:match-day -- debugUnitTestCompileClasspath --> :core:common
+|  :features:match-day -- debugUnitTestCompileClasspath --> :core:footballinfo
+|  :features:match-day -- debugUnitTestCompileClasspath --> :core:design-system
+|  :features:match-day -- debugUnitTestCompileClasspath --> :core:reddit
+|  :features:match-day -- implementation --> :core:common
+|  :features:match-day -- implementation --> :core:footballinfo
+|  :features:match-day -- implementation --> :core:design-system
+|  :features:match-day -- implementation --> :core:reddit
+|  :features:match-day -- releaseUnitTestCompileClasspath --> :core:common
+|  :features:match-day -- releaseUnitTestCompileClasspath --> :core:footballinfo
+|  :features:match-day -- releaseUnitTestCompileClasspath --> :core:design-system
+|  :features:match-day -- releaseUnitTestCompileClasspath --> :core:reddit
+|  :features:match-thread -- debugAndroidTestCompileClasspath --> :core:webview-to-native-player
+|  :features:match-thread -- debugAndroidTestCompileClasspath --> :core:common
+|  :features:match-thread -- debugAndroidTestCompileClasspath --> :core:footballinfo
+|  :features:match-thread -- debugAndroidTestCompileClasspath --> :core:design-system
+|  :features:match-thread -- debugAndroidTestCompileClasspath --> :core:reddit
+|  :features:match-thread -- debugUnitTestCompileClasspath --> :core:webview-to-native-player
+|  :features:match-thread -- debugUnitTestCompileClasspath --> :core:common
+|  :features:match-thread -- debugUnitTestCompileClasspath --> :core:footballinfo
+|  :features:match-thread -- debugUnitTestCompileClasspath --> :core:design-system
+|  :features:match-thread -- debugUnitTestCompileClasspath --> :core:reddit
+|  :features:match-thread -- implementation --> :core:webview-to-native-player
+|  :features:match-thread -- implementation --> :core:common
+|  :features:match-thread -- implementation --> :core:footballinfo
+|  :features:match-thread -- implementation --> :core:design-system
+|  :features:match-thread -- implementation --> :core:reddit
+|  :features:match-thread -- releaseUnitTestCompileClasspath --> :core:webview-to-native-player
+|  :features:match-thread -- releaseUnitTestCompileClasspath --> :core:common
+|  :features:match-thread -- releaseUnitTestCompileClasspath --> :core:footballinfo
+|  :features:match-thread -- releaseUnitTestCompileClasspath --> :core:design-system
+|  :features:match-thread -- releaseUnitTestCompileClasspath --> :core:reddit
+|  :app:playground -- debugAndroidTestCompileClasspath --> :core:webview-to-native-player
+|  :app:playground -- debugAndroidTestCompileClasspath --> :features:match-thread
+|  :app:playground -- debugAndroidTestCompileClasspath --> :core:design-system
+|  :app:playground -- debugUnitTestCompileClasspath --> :core:webview-to-native-player
+|  :app:playground -- debugUnitTestCompileClasspath --> :features:match-thread
+|  :app:playground -- debugUnitTestCompileClasspath --> :core:design-system
+|  :app:playground -- implementation --> :core:webview-to-native-player
+|  :app:playground -- implementation --> :features:match-thread
+|  :app:playground -- implementation --> :core:design-system
+|  :app:playground -- releaseUnitTestCompileClasspath --> :core:webview-to-native-player
+|  :app:playground -- releaseUnitTestCompileClasspath --> :features:match-thread
+|  :app:playground -- releaseUnitTestCompileClasspath --> :core:design-system
+|  :app:playground -- testImplementation --> :features:match-day
+|  :core:reddit -- debugAndroidTestCompileClasspath --> :core:common
+|  :core:reddit -- debugUnitTestCompileClasspath --> :core:common
+|  :core:reddit -- implementation --> :core:common
+|  :core:reddit -- releaseUnitTestCompileClasspath --> :core:common
+|  :core:webview-to-native-player -- implementation --> :core:common
+|  :app:main -- debugAndroidTestCompileClasspath --> :features:match-thread
+|  :app:main -- debugAndroidTestCompileClasspath --> :features:match-day
+|  :app:main -- debugAndroidTestCompileClasspath --> :core:design-system
+|  :app:main -- debugAndroidTestCompileClasspath --> :core:common
+|  :app:main -- debugUnitTestCompileClasspath --> :features:match-thread
+|  :app:main -- debugUnitTestCompileClasspath --> :features:match-day
+|  :app:main -- debugUnitTestCompileClasspath --> :core:design-system
+|  :app:main -- debugUnitTestCompileClasspath --> :core:common
+|  :app:main -- implementation --> :features:match-thread
+|  :app:main -- implementation --> :features:match-day
+|  :app:main -- implementation --> :core:design-system
+|  :app:main -- implementation --> :core:common
+|  :app:main -- releaseUnitTestCompileClasspath --> :features:match-thread
+|  :app:main -- releaseUnitTestCompileClasspath --> :features:match-day
+|  :app:main -- releaseUnitTestCompileClasspath --> :core:design-system
+|  :app:main -- releaseUnitTestCompileClasspath --> :core:common
 """.trimMargin()

--- a/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/graph/FocusNodeStyleWriterTest.kt
+++ b/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/graph/FocusNodeStyleWriterTest.kt
@@ -16,7 +16,7 @@ class FocusNodeStyleWriterTest {
     @Test
     fun `code highlighter works as expected`() {
         val theme = Theme.BASE(focusColor = "#F5A622")
-        val focusedNode = "gama"
+        val focusedNode = ":sample:container:gama"
         val graphOptions = withGraphOptions(
             theme = theme,
             focusedModulesRegex = ".*$focusedNode.*",

--- a/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/graph/SubgraphBuilderTest.kt
+++ b/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/graph/SubgraphBuilderTest.kt
@@ -25,8 +25,8 @@ class SubgraphBuilderTest {
         ).value
 
         val expectedSubgraphSyntax = """
-            |  subgraph groupFolder
-            |    example2
+            |  subgraph :groupFolder
+            |    :groupFolder:example2["example2"]
             |  end
         """.trimMargin()
         assertEquals(expectedSubgraphSyntax, subgraph)
@@ -62,12 +62,12 @@ class SubgraphBuilderTest {
         )
 
         val expectedSubgraphSyntax = """
-            |  subgraph container
-            |    gama
+            |  subgraph :sample
+            |    :sample:alpha["alpha"]
+            |    :sample:zeta["zeta"]
             |  end
-            |  subgraph sample
-            |    alpha
-            |    zeta
+            |  subgraph :sample:container
+            |    :sample:container:gama["gama"]
             |  end
         """.trimMargin()
         assertEquals(expectedSubgraphSyntax, subgraph.value)


### PR DESCRIPTION
## 🚀 Description
This pull request improves the module graph representation by using the full module path as its identifier, a shorter name is used for rendering it.

## 📄 Motivation and Context
Previously, the module graph would use only the module name, which could lead to conflicts, especially in projects with complex structures and repeated modules names. 

By fully qualifying module names in the graph, we eliminate ambiguity and improve the utility of the generated diagrams.

## 🧪 How Has This Been Tested?
Unit tests, integration tests

## 📦 Types of changes
-  [x] Bug fix (non-breaking change which fixes an issue)

## ✅ Checklist
-  [x] My code follows the code style of this project.