### PR TITLE
Fix cache issue on windows

### DIFF
--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/ModuleGraphPlugin.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/ModuleGraphPlugin.kt
@@ -4,6 +4,7 @@ import dev.iurysouza.modulegraph.gradle.graphparser.ProjectParser
 import dev.iurysouza.modulegraph.gradle.graphparser.projectquerier.GradleProjectQuerier
 import dev.iurysouza.modulegraph.model.GraphConfig
 import dev.iurysouza.modulegraph.model.GraphParseResult
+import org.apache.tools.ant.taskdefs.condition.Os
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
@@ -22,6 +23,11 @@ open class ModuleGraphPlugin : Plugin<Project> {
             TASK_NAME,
             CreateModuleGraphTask::class.java,
         ) { task ->
+
+            if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                task.doNotTrackState("https://github.com/iurysza/module-graph/issues/51")
+            }
+
             task.heading.set(extension.heading)
             task.readmePath.set(extension.readmePath)
             task.theme.set(extension.theme)


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
<!-- Describe your changes in detail -->

There's an issue with Gradle identifying cacheable outputs properly on windows which causes the task to fail.
This is not a final solution, but a workaround as I've not identified the root cause.
Side effect: this task may not be cacheable when running on windows.

## 🧪 How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Manually tested on windows environment

## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.