### PR TITLE
feat: add strictMode option

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ moduleGraphConfig {
     // rootModulesRegex = ".*moduleName.*" // optional
     // setStyleByModuleType = true // optional
     // theme = Theme.NEUTRAL // optional
+    // strictMode = false // optional
     // Or you can fully customize it by using the BASE theme:
     // theme = new Theme.BASE(
     //     [
@@ -188,6 +189,7 @@ moduleGraphConfig {
     // focusedModulesRegex.set(".*(projectName).*") // optional
     // rootModulesRegex.set(".*moduleName.*") // optional
     // theme.set(Theme.NEUTRAL) // optional
+    // strictMode.set(false) // optional
     // or you can fully customize it by using the BASE theme:
     // Theme.BASE(
     //     themeVariables = mapOf(
@@ -274,6 +276,7 @@ Optional settings:
     - Regex matching the modules that should be used as root modules.
       If this value is supplied, the generated graph will only include dependencies (direct and transitive) of root modules.
       In other words, the graph will only include modules that can be reached from a root module.
+- **strictMode**: When enabled, the task will fail if any module dependencies cannot be resolved (invalid regex, no modules found, etc). Default is `false`.
 
 ### Multiple graphs
 

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/CreateModuleGraphTask.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/CreateModuleGraphTask.kt
@@ -1,10 +1,6 @@
 package dev.iurysouza.modulegraph.gradle
 
-import dev.iurysouza.modulegraph.LinkText
-import dev.iurysouza.modulegraph.Mermaid
-import dev.iurysouza.modulegraph.Orientation
-import dev.iurysouza.modulegraph.ReadmeWriter
-import dev.iurysouza.modulegraph.Theme
+import dev.iurysouza.modulegraph.*
 import dev.iurysouza.modulegraph.model.GraphConfig
 import dev.iurysouza.modulegraph.model.GraphParseResult
 import org.gradle.api.DefaultTask
@@ -115,6 +111,14 @@ abstract class CreateModuleGraphTask : DefaultTask() {
     @get:OutputDirectory
     @get:Option(option = "projectDirectory", description = "The root project directory")
     internal abstract val projectDirectory: DirectoryProperty
+
+    @get:Input
+    @get:Option(
+        option = "strictMode",
+        description = "Whether to fail the task if no modules are found matching the specified criteria",
+    )
+    @get:Optional
+    abstract val strictMode: Property<Boolean>
 
     init {
         group = "Reporting"

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/ModuleGraphExtension.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/ModuleGraphExtension.kt
@@ -102,6 +102,14 @@ open class ModuleGraphExtension @Inject constructor(project: Project) {
         objects.listProperty(GraphConfig::class.java)
 
     /**
+     * Whether to fail the task if no modules are found matching the specified criteria
+     * (e.g., focusedModulesRegex, rootModulesRegex or single module project).
+     * If set to `false`, the task will no-op if no modules are found.
+     * Defaults to `false`.
+     */
+    val strictMode: Property<Boolean> = objects.property(Boolean::class.java)
+
+    /**
      * Creates a new [GraphConfig] based on the configuration block,
      * and adds it to [graphConfigs].
      * This function provides a DSL for adding graphs.

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/ModuleGraphPlugin.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/ModuleGraphPlugin.kt
@@ -41,6 +41,7 @@ open class ModuleGraphPlugin : Plugin<Project> {
             task.rootModulesRegex.set(extension.rootModulesRegex)
             task.graphConfigs.set(extension.graphConfigs)
             task.projectDirectory.set(project.layout.projectDirectory)
+            task.strictMode.set(extension.strictMode)
 
             val primaryGraphConfig = getPrimaryGraphConfig(task)
             val additionalGraphConfigs = task.graphConfigs.getOrElse(emptyList())
@@ -85,6 +86,7 @@ open class ModuleGraphPlugin : Plugin<Project> {
         val excludedModulesRegex = task.excludedModulesRegex.orNull
         val rootModulesRegex = task.rootModulesRegex.orNull
         val showFullPath = task.showFullPath.orNull
+        val strictMode = task.strictMode.orNull
 
         val params: List<Any?> = listOf(
             readmePath,
@@ -98,6 +100,7 @@ open class ModuleGraphPlugin : Plugin<Project> {
             excludedModulesRegex,
             rootModulesRegex,
             showFullPath,
+            strictMode,
         )
 
         /**
@@ -129,6 +132,7 @@ open class ModuleGraphPlugin : Plugin<Project> {
             this.excludedModulesRegex = excludedModulesRegex
             this.rootModulesRegex = rootModulesRegex
             this.focusedModulesRegex = focusedModulesRegex
+            this.strictMode = strictMode
         }.build()
     }
 }

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/graphparser/ProjectParser.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/graphparser/ProjectParser.kt
@@ -37,7 +37,7 @@ internal object ProjectParser {
             |Current configuration:
             |$config
             |If you intend to generate a graph without root module restrictions, disable strict mode by setting 'strictMode = false' in your moduleGraphConfig.
-            """.trimMargin()
+        """.trimMargin()
 
         val commonMessage = """
             |No modules were found matching the 'rootModulesRegex' configuration.
@@ -52,9 +52,9 @@ internal object ProjectParser {
         }
 
         if (config.strictMode) {
-            require(rootModules.isNotEmpty()) { "\n${errorMsg}" }
+            require(rootModules.isNotEmpty()) { "\n$errorMsg" }
         } else if (rootModules.isEmpty()) {
-            println("\n${errorMsg}")
+            println("\n$errorMsg")
         }
         return parseFromRoots(
             rootModulePaths = rootModules,

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/graph/DigraphBuilder.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/graph/DigraphBuilder.kt
@@ -77,7 +77,7 @@ internal object DigraphBuilder {
                     |1. The regex pattern is correct and matches your intended modules
                     |2. The modules you want to focus on exist in your project
                     |3. The modules are not being excluded by other configuration settings
-            """.trimMargin()
+        """.trimMargin()
         if (strictMode) {
             require(modelList.isNotEmpty()) { errorMsg }
         } else {
@@ -100,7 +100,7 @@ internal object DigraphBuilder {
                     |$config
                     |
                     |Try adjusting the exclusion/inclusion patterns if needed.
-            """.trimMargin()
+        """.trimMargin()
 
         if (strictMode) {
             require(graphModel.keys.size > 1 || dependencies > 0) { errorMsg }

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/model/GraphConfig.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/model/GraphConfig.kt
@@ -67,6 +67,13 @@ data class GraphConfig(
     val excludedModulesRegex: String?,
 
     /**
+     * Whether to fail the task if no modules are found matching the specified criteria
+     * (e.g., focusedModulesRegex, rootModulesRegex).
+     * If set to `false`, the task will silently no-op if no modules are found.
+     */
+    val strictMode: Boolean,
+
+    /**
      * A Regex to match modules that should be used as root modules.
      * If this value is supplied,
      * the generated graph will only include dependencies (direct and transitive) of root modules.
@@ -108,7 +115,11 @@ data class GraphConfig(
         /** @see [GraphConfig.focusedModulesRegex] */
         var focusedModulesRegex: String? = null
 
-        /** Handles default values */
+        /**
+         * See [GraphConfig.strictMode]
+         */
+        var strictMode: Boolean? = null
+
         internal fun build() = GraphConfig(
             readmePath = readmePath,
             heading = heading,
@@ -121,6 +132,7 @@ data class GraphConfig(
             excludedModulesRegex = excludedModulesRegex,
             rootModulesRegex = rootModulesRegex,
             showFullPath = showFullPath ?: false,
+            strictMode = strictMode ?: false,
         )
     }
 }

--- a/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/ModuleGraphPluginFunctionalTest.kt
+++ b/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/ModuleGraphPluginFunctionalTest.kt
@@ -3,10 +3,7 @@ package dev.iurysouza.modulegraph
 import java.io.File
 import kotlin.random.Random
 import org.gradle.testkit.runner.GradleRunner
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertThrows
-import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -468,7 +465,7 @@ class ModuleGraphPluginFunctionalTest {
     }
 
     @Test
-    fun `plugin throws exception when single module project is used`() {
+    fun `plugin throws exception when single module project is used and strictMode is ON`() {
         settingsFile.writeText(
             """
             rootProject.name = "test"
@@ -485,6 +482,7 @@ class ModuleGraphPluginFunctionalTest {
 
             moduleGraphConfig {
                 heading.set("### Dependency Diagram")
+                strictMode.set(true)
                 readmePath.set("${readmeFilePath()}")
             }
             """.trimIndent(),
@@ -499,7 +497,7 @@ class ModuleGraphPluginFunctionalTest {
     }
 
     @Test
-    fun `plugin throws exception when invalid focusedModulesRegex is provided`() {
+    fun `plugin throws exception when invalid focusedModulesRegex is provided and strictMode is ON`() {
         settingsFile.writeText(
             """
             rootProject.name = "test"
@@ -521,6 +519,7 @@ class ModuleGraphPluginFunctionalTest {
                 showFullPath.set(true)
                 focusedModulesRegex.set("$invalidPattern")
                 heading.set("### Dependency Diagram")
+                strictMode.set(true)
                 readmePath.set("${readmeFilePath()}")
                 theme.set($MODULEGRAPH_PACKAGE.Theme.BASE(focusColor = "#F5A622"))
             }
@@ -540,7 +539,7 @@ class ModuleGraphPluginFunctionalTest {
     }
 
     @Test
-    fun `plugin throws exception when excludedModuleMatch causes the graph to be empty`() {
+    fun `plugin throws exception when excludedModuleMatch causes the graph to be empty and strictMode is ON`() {
         settingsFile.writeText(
             """
             rootProject.name = "test"
@@ -561,7 +560,7 @@ class ModuleGraphPluginFunctionalTest {
             moduleGraphConfig {
                 heading.set("### Dependency Diagram")
                 readmePath.set("${readmeFilePath()}")
-
+                strictMode.set(true)
                 excludedModulesRegex.set("$invalidPattern")
             }
             dependencies {

--- a/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/graph/Fixtures.kt
+++ b/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/graph/Fixtures.kt
@@ -84,6 +84,7 @@ internal fun getConfig(
     linkText: LinkText? = null,
     setStyleByModuleType: Boolean? = null,
     showFullPath: Boolean? = null,
+    strictMode: Boolean? = null,
 ) =
     GraphConfig.Builder(
         readmePath = readmePath,
@@ -98,6 +99,7 @@ internal fun getConfig(
         this.linkText = linkText
         this.setStyleByModuleType = setStyleByModuleType
         this.showFullPath = showFullPath
+        this.strictMode = strictMode
     }.build()
 
 internal val liveMatchReconstructedModel = mapOf(

--- a/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/graph/MermaidGraphTest.kt
+++ b/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/graph/MermaidGraphTest.kt
@@ -47,7 +47,7 @@ class MermaidGraphTest {
     }
 
     @Test
-    fun `Given a single module project and StrictMode is ON, when generating graph, then it throws IllegalArgumentException`() {
+    fun `Given a single module and StrictMode is ON, when generating graph, then it throws IllegalArgumentException`() {
         val graphModel = mapOf(Module(":example") to listOf<Module>())
         val result = GraphParseResult(graphModel, getConfig(strictMode = true))
 

--- a/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/graph/MermaidGraphTest.kt
+++ b/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/graph/MermaidGraphTest.kt
@@ -1,6 +1,8 @@
 package dev.iurysouza.modulegraph.graph
 
-import dev.iurysouza.modulegraph.*
+import dev.iurysouza.modulegraph.Mermaid
+import dev.iurysouza.modulegraph.Orientation
+import dev.iurysouza.modulegraph.Theme
 import dev.iurysouza.modulegraph.gradle.Module
 import dev.iurysouza.modulegraph.model.GraphParseResult
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -45,9 +47,9 @@ class MermaidGraphTest {
     }
 
     @Test
-    fun `Given a single module project, when generating graph, then it throws IllegalArgumentException`() {
+    fun `Given a single module project and StrictMode is ON, when generating graph, then it throws IllegalArgumentException`() {
         val graphModel = mapOf(Module(":example") to listOf<Module>())
-        val result = GraphParseResult(graphModel, getConfig())
+        val result = GraphParseResult(graphModel, getConfig(strictMode = true))
 
         assertThrows<IllegalArgumentException> {
             Mermaid.generateGraph(result)

--- a/sample/README.md
+++ b/sample/README.md
@@ -30,6 +30,7 @@ graph TB
     :sample:zeta["zeta"]
     :sample:beta["beta"]
     :sample:alpha["alpha"]
+    :sample:test["test"]
   end
   subgraph :sample:container
     :sample:container:gama["gama"]
@@ -41,6 +42,7 @@ graph TB
   :sample:alpha --> :sample:beta
   :sample:alpha --> :sample:container:gama
   :sample:alpha --> :sample:container:delta
+  :sample:alpha --> :sample:test
 
 classDef java fill:#B5661C,stroke:#fff,stroke-width:2px,color:#fff;
 class :sample:container:gama java
@@ -48,6 +50,7 @@ class :sample:zeta java
 class :sample:beta java
 class :sample:alpha java
 class :sample:container:delta java
+class :sample:test java
 
 ```
 # Graph with root: gama
@@ -60,13 +63,5 @@ class :sample:container:delta java
 }%%
 
 graph LR
-  subgraph :sample
-    :sample:zeta["zeta"]
-    :sample:beta["beta"]
-  end
-  subgraph :sample:container
-    :sample:container:gama["gama"]
-  end
-  :sample:container:gama --> :sample:zeta
-  :sample:zeta --> :sample:beta
+
 ```

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -22,6 +22,7 @@ moduleGraphConfig {
     orientation.set(Orientation.TOP_TO_BOTTOM)
     linkText.set(LinkText.NONE)
     setStyleByModuleType.set(true)
+    // strictMode.set(false)
     theme.set(
         Theme.BASE(
             themeVariables = mapOf(

--- a/sample/build.gradle.x
+++ b/sample/build.gradle.x
@@ -26,6 +26,8 @@ moduleGraphConfig {
     // focusedModulesRegex.set(""".*gama.*""")
     // excludedModulesRegex.set(".*alpha.*")
     // rootModulesRegex.set(".*gama.*")
+    // strictMode.set(true)
+
 
     /* Primary graph - optional theme */
     def customTheme = new Theme.BASE()


### PR DESCRIPTION
## 🚀 Description
Adds `strictMode` option (default: `false`) to the Module Graph plugin. When enabled, the task fails if no modules match criteria (e.g., `rootModulesRegex`). When disabled, the task no-ops with a warning. Improves error/warning messages for clarity.

## 📄 Motivation and Context
Fixes #55. Allows non-failing behavior when no modules match, simplifying convention plugin usage in projects without graphable modules. Provides flexibility for optional graph generation.

## 🧪 How Has This Been Tested?
*   Added functional tests for `strictMode = true` (failure) and `strictMode = false` (no-op) scenarios, including cases with `focusedModulesRegex` and empty projects.
*   Manually tested in the `sample` project.

## 📦 Types of changes
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## ✅ Checklist
- [x] Code style followed.
- [x] Documentation updated.
- [x] Documentation updated accordingly.
