### PR TITLE
Implement nested subgraphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,7 +649,8 @@ Given these modules:
 ```mermaid
 %%{
   init: {
-    'theme': 'neutral'
+    'theme': 'base',
+    'themeVariables': {"primaryTextColor":"#fff","primaryColor":"#5a4f7c","primaryBorderColor":"#5a4f7c","lineColor":"#f5a623","tertiaryColor":"#40375c","fontSize":"12px"}
   }
 }%%
 
@@ -664,7 +665,7 @@ graph LR
   :App --> :libs:app-common
   :App --> :libs:crash-reporting:api
   :App --> :libs:crash-reporting:firebase
-  classDef focus fill:#769566,stroke:#fff,stroke-width:2px,color:#fff;
+  classDef focus fill:#E04380,stroke:#fff,stroke-width:2px,color:#fff;
   class :App focus
 ```
 
@@ -672,7 +673,8 @@ graph LR
 ```mermaid
 %%{
   init: {
-    'theme': 'neutral'
+    'theme': 'base',
+    'themeVariables': {"primaryTextColor":"#fff","primaryColor":"#5a4f7c","primaryBorderColor":"#5a4f7c","lineColor":"#f5a623","tertiaryColor":"#40375c","fontSize":"12px"}
   }
 }%%
 
@@ -687,9 +689,8 @@ graph LR
   :App --> :libs:app-common
   :App --> :libs:crash-reporting:api
   :App --> :libs:crash-reporting:firebase
-  classDef focus fill:#769566,stroke:#fff,stroke-width:2px,color:#fff;
+  classDef focus fill:#E04380,stroke:#fff,stroke-width:2px,color:#fff;
   class :App focus
-
 ```
 
 Nested subgraphs can help better visualize your project's module hierarchy, especially in larger projects with many nested modules. Note that this feature is automatically disabled if `showFullPath` is true.
@@ -710,7 +711,8 @@ This will display the complete path for each module without any subgraph groupin
 ```mermaid
 %%{
   init: {
-    'theme': 'neutral'
+    'theme': 'base',
+    'themeVariables': {"primaryTextColor":"#fff","primaryColor":"#5a4f7c","primaryBorderColor":"#5a4f7c","lineColor":"#f5a623","tertiaryColor":"#40375c","fontSize":"12px"}
   }
 }%%
 
@@ -722,12 +724,11 @@ graph LR
   :App --> :libs:app-common
   :App --> :libs:crash-reporting:api
   :App --> :libs:crash-reporting:firebase
-  classDef focus fill:#769566,stroke:#fff,stroke-width:2px,color:#fff;
+  classDef focus fill:#E04380,stroke:#fff,stroke-width:2px,color:#fff;
   class :App focus
 ```
 
 This view can be useful when you want to see the full module paths at a glance without any grouping structure.
-
 
 ## Contributing 🤝
 

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Required settings:
 
 Optional settings:
 
-- **setStyleByModuleType**: Whether to style the modules based on their type (KotlinMultiplatform, Android Library, etc). Default is `false`. [Read more](#module-type-based-styling).
+- **setStyleByModuleType**: Whether to style the modules based on their type (KotlinMultiplatform, Android Library, etc.). Default is `false`. [Read more](#module-type-based-styling).
 - **nestingEnabled**: Whether to enable nested subgraphs in the generated graph. Groups modules into subgraphs based on their path structure. Default is `false`. [Read more](#nested-subgraphs).
 - **focusedModulesRegex**: The regex to match nodes in the graph (project names) that should be focused. By
   default, no nodes are focused.
@@ -277,7 +277,7 @@ Optional settings:
     - Regex matching the modules that should be used as root modules.
       If this value is supplied, the generated graph will only include dependencies (direct and transitive) of root modules.
       In other words, the graph will only include modules that can be reached from a root module.
-- **strictMode**: When enabled, the task will fail if any module dependencies cannot be resolved (invalid regex, no modules found, etc). Default is `false`.
+- **strictMode**: When enabled, the task will fail if any module dependencies cannot be resolved (invalid regex, no modules found, etc.). Default is `false`.
 
 ### Multiple graphs
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ plugins {
     }
 }
 
-apply(plugin = "dev.iurysouza:modulegraph")
+apply(plugin = "dev.iurysouza.modulegraph")
 ```
 
 </details>
@@ -251,6 +251,7 @@ Required settings:
 Optional settings:
 
 - **setStyleByModuleType**: Whether to style the modules based on their type (KotlinMultiplatform, Android Library, etc). Default is `false`. [Read more](#module-type-based-styling).
+- **nestingEnabled**: Whether to enable nested subgraphs in the generated graph. Groups modules into subgraphs based on their path structure. Default is `false`. [Read more](#nested-subgraphs).
 - **focusedModulesRegex**: The regex to match nodes in the graph (project names) that should be focused. By
   default, no nodes are focused.
   If set, the matching nodes will be highlighted and only related nodes will be shown. The color can be customized via the `focusColor` property
@@ -624,6 +625,109 @@ The system determines the module type based on the hierarchy of applied plugins.
 
 - A module with both `React Native` and `Android Library` will be identified as `React Native`.
 - A module with both `Android Library` and `Kotlin` will be identified as `Android Library`.
+
+## Nested Subgraphs
+
+The plugin supports two ways of organizing modules in the graph: flat subgraphs (default) and nested subgraphs. You can enable nested subgraphs using the `nestingEnabled` property:
+
+```kotlin
+moduleGraphConfig {
+    //... keep previous configs
+    nestingEnabled.set(true)
+}
+```
+
+### Flat vs Nested Example
+
+Given these modules:
+- :App
+- :libs:crash-reporting:api
+- :libs:crash-reporting:firebase
+- :libs:app-common
+
+**Flat subgraphs** (default):
+```mermaid
+%%{
+  init: {
+    'theme': 'neutral'
+  }
+}%%
+
+graph LR
+  subgraph :libs
+    :libs:app-common["app-common"]
+  end
+  subgraph :libs:crash-reporting
+    :libs:crash-reporting:api["api"]
+    :libs:crash-reporting:firebase["firebase"]
+  end
+  :App --> :libs:app-common
+  :App --> :libs:crash-reporting:api
+  :App --> :libs:crash-reporting:firebase
+  classDef focus fill:#769566,stroke:#fff,stroke-width:2px,color:#fff;
+  class :App focus
+```
+
+**Nested subgraphs** (with `nestingEnabled = true`):
+```mermaid
+%%{
+  init: {
+    'theme': 'neutral'
+  }
+}%%
+
+graph LR
+  subgraph :libs
+    :libs:app-common["app-common"]
+    subgraph :crash-reporting
+      :libs:crash-reporting:api["api"]
+      :libs:crash-reporting:firebase["firebase"]
+    end
+  end
+  :App --> :libs:app-common
+  :App --> :libs:crash-reporting:api
+  :App --> :libs:crash-reporting:firebase
+  classDef focus fill:#769566,stroke:#fff,stroke-width:2px,color:#fff;
+  class :App focus
+
+```
+
+Nested subgraphs can help better visualize your project's module hierarchy, especially in larger projects with many nested modules. Note that this feature is automatically disabled if `showFullPath` is true.
+
+### Full Path View
+
+You can also choose to show the full path of each module using the `showFullPath` property:
+
+```kotlin
+moduleGraphConfig {
+    //... keep previous configs
+    showFullPath.set(true)
+}
+```
+
+This will display the complete path for each module without any subgraph grouping:
+
+```mermaid
+%%{
+  init: {
+    'theme': 'neutral'
+  }
+}%%
+
+graph LR
+  :App
+  :libs:app-common
+  :libs:crash-reporting:api
+  :libs:crash-reporting:firebase
+  :App --> :libs:app-common
+  :App --> :libs:crash-reporting:api
+  :App --> :libs:crash-reporting:firebase
+  classDef focus fill:#769566,stroke:#fff,stroke-width:2px,color:#fff;
+  class :App focus
+```
+
+This view can be useful when you want to see the full module paths at a glance without any grouping structure.
+
 
 ## Contributing 🤝
 

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/Mermaid.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/Mermaid.kt
@@ -1,5 +1,6 @@
 package dev.iurysouza.modulegraph
 
+import dev.iurysouza.modulegraph.graph.subgraph.SubgraphBuilder
 import dev.iurysouza.modulegraph.graph.*
 import dev.iurysouza.modulegraph.model.GraphParseResult
 
@@ -11,7 +12,7 @@ internal object Mermaid {
         val digraph = DigraphBuilder.build(result)
 
         val configCode = ConfigCodeBuilder.build(config.theme)
-        val subgraphCode = SubgraphBuilder.build(digraph, config.showFullPath)
+        val subgraphCode = SubgraphBuilder.build(digraph, config)
         val digraphCode = DigraphCodeBuilder.build(digraph, config.linkText)
         val highlightCode = NodeStyleBuilder.build(digraph, config)
         val orientationName = config.orientation.value

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/Mermaid.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/Mermaid.kt
@@ -1,7 +1,7 @@
 package dev.iurysouza.modulegraph
 
-import dev.iurysouza.modulegraph.graph.subgraph.SubgraphBuilder
 import dev.iurysouza.modulegraph.graph.*
+import dev.iurysouza.modulegraph.graph.subgraph.SubgraphBuilder
 import dev.iurysouza.modulegraph.model.GraphParseResult
 
 internal object Mermaid {

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/CreateModuleGraphTask.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/CreateModuleGraphTask.kt
@@ -105,6 +105,14 @@ abstract class CreateModuleGraphTask : DefaultTask() {
     abstract val setStyleByModuleType: Property<Boolean>
 
     @get:Input
+    @get:Option(
+        option = "nestingEnabled",
+        description = "Whether to enable nested subgraphs in the generated graph",
+    )
+    @get:Optional
+    abstract val nestingEnabled: Property<Boolean>
+
+    @get:Input
     @get:Option(option = "graphModels", description = "The produced graph models")
     internal abstract val graphModels: ListProperty<GraphParseResult>
 

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/ModuleGraphExtension.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/ModuleGraphExtension.kt
@@ -96,18 +96,26 @@ open class ModuleGraphExtension @Inject constructor(project: Project) {
     val showFullPath: Property<Boolean> = objects.property(Boolean::class.java)
 
     /**
-     * A list of additional graph configs to generate graphs for.
-     */
-    val graphConfigs: ListProperty<GraphConfig> =
-        objects.listProperty(GraphConfig::class.java)
-
-    /**
      * Whether to fail the task if no modules are found matching the specified criteria
      * (e.g., focusedModulesRegex, rootModulesRegex or single module project).
      * If set to `false`, the task will no-op if no modules are found.
      * Defaults to `false`.
      */
     val strictMode: Property<Boolean> = objects.property(Boolean::class.java)
+
+    /**
+     * Whether to enable nested subgraphs in the generated graph.
+     * When enabled, modules will be grouped into subgraphs based on their path structure.
+     * For example, modules under ":libs:feature1" and ":libs:feature2" will be nested under a ":libs" subgraph.
+     * Note: This option is ignored if [showFullPath] is true.
+     */
+    val nestingEnabled: Property<Boolean> = objects.property(Boolean::class.java)
+
+    /**
+     * A list of additional graph configs to generate graphs for.
+     */
+    val graphConfigs: ListProperty<GraphConfig> =
+        objects.listProperty(GraphConfig::class.java)
 
     /**
      * Creates a new [GraphConfig] based on the configuration block,

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/ModuleGraphPlugin.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/ModuleGraphPlugin.kt
@@ -42,6 +42,7 @@ open class ModuleGraphPlugin : Plugin<Project> {
             task.graphConfigs.set(extension.graphConfigs)
             task.projectDirectory.set(project.layout.projectDirectory)
             task.strictMode.set(extension.strictMode)
+            task.nestingEnabled.set(extension.nestingEnabled)
 
             val primaryGraphConfig = getPrimaryGraphConfig(task)
             val additionalGraphConfigs = task.graphConfigs.getOrElse(emptyList())
@@ -87,6 +88,7 @@ open class ModuleGraphPlugin : Plugin<Project> {
         val rootModulesRegex = task.rootModulesRegex.orNull
         val showFullPath = task.showFullPath.orNull
         val strictMode = task.strictMode.orNull
+        val nestingEnabled = task.nestingEnabled.orNull
 
         val params: List<Any?> = listOf(
             readmePath,
@@ -101,6 +103,7 @@ open class ModuleGraphPlugin : Plugin<Project> {
             rootModulesRegex,
             showFullPath,
             strictMode,
+            nestingEnabled,
         )
 
         /**
@@ -133,6 +136,7 @@ open class ModuleGraphPlugin : Plugin<Project> {
             this.rootModulesRegex = rootModulesRegex
             this.focusedModulesRegex = focusedModulesRegex
             this.strictMode = strictMode
+            this.nestingEnabled = nestingEnabled
         }.build()
     }
 }

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/graph/DigraphBuilder.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/graph/DigraphBuilder.kt
@@ -70,7 +70,7 @@ internal object DigraphBuilder {
 
     private fun throwIfNothingMatches(modelList: List<DigraphModel>, regex: String?, strictMode: Boolean) {
         if (!modelList.isEmpty()) return
-        
+
         val errorMsg = """
             |No modules were found matching the pattern: $regex
             |This pattern was configured through the `focusedModulesRegex` property.

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/graph/DigraphBuilder.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/graph/DigraphBuilder.kt
@@ -69,20 +69,18 @@ internal object DigraphBuilder {
     }
 
     private fun throwIfNothingMatches(modelList: List<DigraphModel>, regex: String?, strictMode: Boolean) {
+        if (!modelList.isEmpty()) return
+        
         val errorMsg = """
-                    |
-                    |No modules were found matching the pattern: $regex
-                    |This pattern was configured through the `focusedModulesRegex` property.
-                    |Please verify that:
-                    |1. The regex pattern is correct and matches your intended modules
-                    |2. The modules you want to focus on exist in your project
-                    |3. The modules are not being excluded by other configuration settings
+            |No modules were found matching the pattern: $regex
+            |This pattern was configured through the `focusedModulesRegex` property.
+            |Please verify that:
+            |1. The regex pattern is correct and matches your intended modules
+            |2. The modules you want to focus on exist in your project
+            |3. The modules are not being excluded by other configuration settings
         """.trimMargin()
-        if (strictMode) {
-            require(modelList.isNotEmpty()) { errorMsg }
-        } else {
-            println(errorMsg)
-        }
+
+        if (strictMode) error(errorMsg) else println(errorMsg)
     }
 
     private fun verifySufficientGraph(graphResult: GraphParseResult, strictMode: Boolean) {

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/graph/DigraphBuilder.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/graph/DigraphBuilder.kt
@@ -50,7 +50,7 @@ internal object DigraphBuilder {
             else -> DigraphModel(
                 source = ModuleNode(
                     name = sourceFullName.getProjectName(showFullPath),
-                    fullName = sourceFullName,
+                    fullPath = sourceFullName,
                     isFocused = sourceMatches && isFocusedModulesRegexSet,
                     config = ModuleConfig.none(),
                     type = source.type,
@@ -58,7 +58,7 @@ internal object DigraphBuilder {
                 ),
                 target = ModuleNode(
                     name = targetFullName!!.getProjectName(showFullPath),
-                    fullName = targetFullName,
+                    fullPath = targetFullName,
                     isFocused = targetMatches && isFocusedModulesRegexSet,
                     config = target.configName?.let { ModuleConfig(it) } ?: ModuleConfig.none(),
                     type = target.type,

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/graph/DigraphCodeBuilder.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/graph/DigraphCodeBuilder.kt
@@ -28,7 +28,7 @@ internal object DigraphCodeBuilder {
     )
 
     private fun toMermaid(it: DigraphModel, linkText: LinkText): CharSequence = """
-        |  ${it.source.fullName} ${linkText.toLinkString(it.target.config.value)} ${it.target.fullName}
+        |  ${it.source.fullPath} ${linkText.toLinkString(it.target.config.value)} ${it.target.fullPath}
     """.trimMargin()
 }
 

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/graph/Models.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/graph/Models.kt
@@ -10,10 +10,19 @@ internal data class DigraphModel(
 internal data class ModuleNode(
     val name: String,
     val isFocused: Boolean,
-    val fullName: String,
+    val fullPath: String,
     val config: ModuleConfig,
     val type: ModuleType,
     val parent: String,
+) {
+    val pathSegments: List<String> get() = fullPath.split(':').filter { it.isNotEmpty() }
+}
+
+internal data class PathNode(
+    val name: String,
+    val fullPath: String,
+    val children: MutableMap<String, PathNode> = mutableMapOf(),
+    val modules: MutableList<ModuleNode> = mutableListOf(),
 )
 
 @JvmInline

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/graph/NodeStyleBuilder.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/graph/NodeStyleBuilder.kt
@@ -25,7 +25,7 @@ internal object NodeStyleBuilder {
     fun build(digraphModel: List<DigraphModel>, config: GraphConfig): MermaidCode {
         val distinctNodes = digraphModel
             .flatMap { listOf(it.source, it.target) }
-            .distinctBy { it.fullName }
+            .distinctBy { it.fullPath }
 
         val pluginTypeStyling = applyStylingByPluginType(distinctNodes, config)
         val focusedNodesStyling = highlightFocusedNodes(distinctNodes, config)
@@ -56,7 +56,7 @@ internal object NodeStyleBuilder {
             }
             """.trimMargin() + """
                 |
-                |${nodeList.joinToString("\n") { "class ${it.fullName} ${it.pluginClass()}" }}
+                |${nodeList.joinToString("\n") { "class ${it.fullPath} ${it.pluginClass()}" }}
             """.trimMargin()
         } else {
             ""
@@ -81,7 +81,7 @@ internal object NodeStyleBuilder {
             """
                |
                |${defineStyleClass(FOCUS_CLASS_NAME, config.theme.focusColor())}
-               |${nodeList.filter { it.isFocused }.joinToString("\n") { "class ${it.fullName} $FOCUS_CLASS_NAME" }}
+               |${nodeList.filter { it.isFocused }.joinToString("\n") { "class ${it.fullPath} $FOCUS_CLASS_NAME" }}
             """.trimMargin()
         },
     )

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/graph/subgraph/FlatSubgraphBuilder.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/graph/subgraph/FlatSubgraphBuilder.kt
@@ -8,8 +8,10 @@ internal object FlatSubgraphBuilder {
 
     /**
      * The `build` function groups digraph models by parent and generates mermaid syntax for subgraphs.
+     * This builder is used when [GraphConfig.nestingEnabled] is false or [GraphConfig.showFullPath] is true.
      *
      * @param list The list of digraph models to be grouped by parent.
+     * @param showFullPath Whether to show the full path of modules in the graph.
      * @return The resulting `MermaidCode` corresponding to the structured digraphs.
      *
      * eg.:
@@ -23,7 +25,7 @@ internal object FlatSubgraphBuilder {
      *  end
      *```
      *
-     *Where "sample" and "container" are parent nodes, and "alpha", "zeta", and "gama" are children.
+     * Where "sample" and "container" are parent nodes, and "alpha", "zeta", and "gama" are children.
      */
     fun build(list: List<DigraphModel>, showFullPath: Boolean): MermaidCode {
         if (showFullPath) return MermaidCode.EMPTY

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/graph/subgraph/FlatSubgraphBuilder.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/graph/subgraph/FlatSubgraphBuilder.kt
@@ -1,6 +1,10 @@
-package dev.iurysouza.modulegraph.graph
+package dev.iurysouza.modulegraph.graph.subgraph
 
-internal object SubgraphBuilder {
+import dev.iurysouza.modulegraph.graph.DigraphModel
+import dev.iurysouza.modulegraph.graph.MermaidCode
+import dev.iurysouza.modulegraph.graph.ModuleNode
+
+internal object FlatSubgraphBuilder {
 
     /**
      * The `build` function groups digraph models by parent and generates mermaid syntax for subgraphs.
@@ -31,7 +35,7 @@ internal object SubgraphBuilder {
         subgraphModel: List<Pair<String, List<ModuleNode>>>,
     ): MermaidCode = MermaidCode(
         subgraphModel.joinToString("\n") { (parent, children) ->
-            val childrenNames = children.joinToString("\n") { """    ${it.fullName}["${it.name}"]""" }
+            val childrenNames = children.joinToString("\n") { """    ${it.fullPath}["${it.name}"]""" }
             """|  subgraph $parent
                |$childrenNames
                |  end
@@ -45,7 +49,7 @@ internal object SubgraphBuilder {
         .flatMap { listOf(it.source, it.target) }
         .filter { it.parent.isNotEmpty() }
         .groupBy { it.parent }
-        .map { (parent, children) -> parent to children.distinctBy { it.fullName } }
+        .map { (parent, children) -> parent to children.distinctBy { it.fullPath } }
         .sortedBy { it.first }
         .toList()
 }

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/graph/subgraph/NestedSubgraphBuilder.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/graph/subgraph/NestedSubgraphBuilder.kt
@@ -41,7 +41,7 @@ internal object NestedSubgraphBuilder {
         }
     }
 
-    private fun generateNestedSubgraphs(node: PathNode, depth: Int = 1): String {
+    private fun generateNestedSubgraphs(node: PathNode, depth: Int = 0): String {
         // If empty, do nothing
         if (node.children.isEmpty() && node.modules.isEmpty()) return ""
         return buildString {

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/graph/subgraph/NestedSubgraphBuilder.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/graph/subgraph/NestedSubgraphBuilder.kt
@@ -1,0 +1,92 @@
+package dev.iurysouza.modulegraph.graph.subgraph
+
+import dev.iurysouza.modulegraph.graph.DigraphModel
+import dev.iurysouza.modulegraph.graph.MermaidCode
+import dev.iurysouza.modulegraph.graph.ModuleNode
+import dev.iurysouza.modulegraph.graph.PathNode
+
+internal class NestedSubgraphBuilder {
+    companion object {
+        fun build(digraphModels: List<DigraphModel>): MermaidCode {
+            val modules = extractUniqueModules(digraphModels)
+            val tree = buildModuleTree(modules)
+            return MermaidCode(generateNestedSubgraphs(tree))
+        }
+
+        private fun ident(level: Int): String = buildString {
+            repeat(level * 2) {
+                append(" ")
+            }
+        }
+
+        private fun generateNestedSubgraphs(node: PathNode, depth: Int = 1): String {
+            // If empty, do nothing
+            if (node.children.isEmpty() && node.modules.isEmpty()) return ""
+            return buildString {
+                // Get module name from the node's full path
+                // For ":libs:crash-reporting", the name is ":crash-reporting"
+                // If substringAfterLast(":") is empty we on the top level already
+                val moduleName = node.fullPath
+                    .substringAfterLast(":")
+                    .takeIf { it.isNotBlank() }
+                    ?.let { ":$it" }
+                    ?: node.fullPath
+
+                val shouldOpenSubgraph = node.name != "root"
+                if (shouldOpenSubgraph) {
+                    append("${ident(depth)}subgraph $moduleName\n")
+                }
+
+                // List all modules belonging to this node, using full path for IDs
+                node.modules.forEach { module ->
+                    val leafName = module.fullPath.substringAfterLast(":")
+                    append("${ident(depth + 1)}${module.fullPath}[\"$leafName\"]\n")
+                }
+
+                // Recurse into child nodes
+                node.children.values.forEach { child ->
+                    append(generateNestedSubgraphs(child, depth + 1))
+                }
+
+                // Close subgraph if opened
+                if (shouldOpenSubgraph) {
+                    append("${ident(depth)}end\n")
+                }
+            }
+        }
+
+        private fun buildModuleTree(nodes: Set<ModuleNode>): PathNode {
+            val root = PathNode("root", "")
+            nodes.forEach { node ->
+
+                val pathSegments = node.pathSegments
+                if (pathSegments.isEmpty()) return@forEach
+
+                // Separate parent segments from the final leaf name
+                val parentSegments = pathSegments.dropLast(1)
+                var current = root
+
+                // Build out intermediate path nodes
+                parentSegments.forEach { segment ->
+                    current = current.children.getOrPut(segment) {
+                        PathNode(
+                            name = segment,
+                            fullPath = buildFullPath(current.fullPath, segment),
+                        )
+                    }
+                }
+                // Add the module to its parent; do not create a separate subgraph for the final segment
+                current.modules.add(node.copy(name = pathSegments.last()))
+            }
+            return root
+        }
+
+        private fun buildFullPath(current: String, segment: String): String {
+            return if (current.isEmpty()) ":$segment" else "$current:$segment"
+        }
+
+        private fun extractUniqueModules(models: List<DigraphModel>): Set<ModuleNode> {
+            return models.flatMap { listOf(it.source, it.target) }.toSet()
+        }
+    }
+}

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/graph/subgraph/NestedSubgraphBuilder.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/graph/subgraph/NestedSubgraphBuilder.kt
@@ -5,88 +5,109 @@ import dev.iurysouza.modulegraph.graph.MermaidCode
 import dev.iurysouza.modulegraph.graph.ModuleNode
 import dev.iurysouza.modulegraph.graph.PathNode
 
-internal class NestedSubgraphBuilder {
-    companion object {
-        fun build(digraphModels: List<DigraphModel>): MermaidCode {
-            val modules = extractUniqueModules(digraphModels)
-            val tree = buildModuleTree(modules)
-            return MermaidCode(generateNestedSubgraphs(tree))
-        }
+internal object NestedSubgraphBuilder {
+    /**
+     * Builds nested subgraphs in the mermaid graph based on module paths.
+     * This builder is used when [GraphConfig.nestingEnabled] is true and [GraphConfig.showFullPath] is false.
+     *
+     * For example, given these modules:
+     * - :libs:crash-reporting:api
+     * - :libs:crash-reporting:firebase
+     * - :libs:app-common
+     *
+     * It will generate nested subgraphs like:
+     * ```
+     * subgraph :libs
+     *   :libs:app-common["app-common"]
+     *   subgraph :crash-reporting
+     *     :libs:crash-reporting:api["api"]
+     *     :libs:crash-reporting:firebase["firebase"]
+     *   end
+     * end
+     * ```
+     *
+     * This creates a hierarchical visualization where modules are grouped by their path structure,
+     * making it easier to understand the project's organization.
+     */
+    fun build(digraphModels: List<DigraphModel>): MermaidCode {
+        val modules = extractUniqueModules(digraphModels)
+        val tree = buildModuleTree(modules)
+        return MermaidCode(generateNestedSubgraphs(tree))
+    }
 
-        private fun ident(level: Int): String = buildString {
-            repeat(level * 2) {
-                append(" ")
+    private fun ident(level: Int): String = buildString {
+        repeat(level * 2) {
+            append(" ")
+        }
+    }
+
+    private fun generateNestedSubgraphs(node: PathNode, depth: Int = 1): String {
+        // If empty, do nothing
+        if (node.children.isEmpty() && node.modules.isEmpty()) return ""
+        return buildString {
+            // Get module name from the node's full path
+            // For ":libs:crash-reporting", the name is ":crash-reporting"
+            // If substringAfterLast(":") is empty we on the top level already
+            val moduleName = node.fullPath
+                .substringAfterLast(":")
+                .takeIf { it.isNotBlank() }
+                ?.let { ":$it" }
+                ?: node.fullPath
+
+            val shouldOpenSubgraph = node.name != "root"
+            if (shouldOpenSubgraph) {
+                append("${ident(depth)}subgraph $moduleName\n")
+            }
+
+            // List all modules belonging to this node, using full path for IDs
+            node.modules.forEach { module ->
+                val leafName = module.fullPath.substringAfterLast(":")
+                append("${ident(depth + 1)}${module.fullPath}[\"$leafName\"]\n")
+            }
+
+            // Recurse into child nodes
+            node.children.values.forEach { child ->
+                append(generateNestedSubgraphs(child, depth + 1))
+            }
+
+            // Close subgraph if opened
+            if (shouldOpenSubgraph) {
+                append("${ident(depth)}end\n")
             }
         }
+    }
 
-        private fun generateNestedSubgraphs(node: PathNode, depth: Int = 1): String {
-            // If empty, do nothing
-            if (node.children.isEmpty() && node.modules.isEmpty()) return ""
-            return buildString {
-                // Get module name from the node's full path
-                // For ":libs:crash-reporting", the name is ":crash-reporting"
-                // If substringAfterLast(":") is empty we on the top level already
-                val moduleName = node.fullPath
-                    .substringAfterLast(":")
-                    .takeIf { it.isNotBlank() }
-                    ?.let { ":$it" }
-                    ?: node.fullPath
+    private fun buildModuleTree(nodes: Set<ModuleNode>): PathNode {
+        val root = PathNode("root", "")
+        nodes.forEach { node ->
 
-                val shouldOpenSubgraph = node.name != "root"
-                if (shouldOpenSubgraph) {
-                    append("${ident(depth)}subgraph $moduleName\n")
-                }
+            val pathSegments = node.pathSegments
+            if (pathSegments.isEmpty()) return@forEach
 
-                // List all modules belonging to this node, using full path for IDs
-                node.modules.forEach { module ->
-                    val leafName = module.fullPath.substringAfterLast(":")
-                    append("${ident(depth + 1)}${module.fullPath}[\"$leafName\"]\n")
-                }
+            // Separate parent segments from the final leaf name
+            val parentSegments = pathSegments.dropLast(1)
+            var current = root
 
-                // Recurse into child nodes
-                node.children.values.forEach { child ->
-                    append(generateNestedSubgraphs(child, depth + 1))
-                }
-
-                // Close subgraph if opened
-                if (shouldOpenSubgraph) {
-                    append("${ident(depth)}end\n")
+            // Build out intermediate path nodes
+            parentSegments.forEach { segment ->
+                current = current.children.getOrPut(segment) {
+                    PathNode(
+                        name = segment,
+                        fullPath = buildFullPath(current.fullPath, segment),
+                    )
                 }
             }
+            // Add the module to its parent; do not create a separate subgraph for the final segment
+            current.modules.add(node.copy(name = pathSegments.last()))
         }
+        return root
+    }
 
-        private fun buildModuleTree(nodes: Set<ModuleNode>): PathNode {
-            val root = PathNode("root", "")
-            nodes.forEach { node ->
+    private fun buildFullPath(current: String, segment: String): String {
+        return if (current.isEmpty()) ":$segment" else "$current:$segment"
+    }
 
-                val pathSegments = node.pathSegments
-                if (pathSegments.isEmpty()) return@forEach
-
-                // Separate parent segments from the final leaf name
-                val parentSegments = pathSegments.dropLast(1)
-                var current = root
-
-                // Build out intermediate path nodes
-                parentSegments.forEach { segment ->
-                    current = current.children.getOrPut(segment) {
-                        PathNode(
-                            name = segment,
-                            fullPath = buildFullPath(current.fullPath, segment),
-                        )
-                    }
-                }
-                // Add the module to its parent; do not create a separate subgraph for the final segment
-                current.modules.add(node.copy(name = pathSegments.last()))
-            }
-            return root
-        }
-
-        private fun buildFullPath(current: String, segment: String): String {
-            return if (current.isEmpty()) ":$segment" else "$current:$segment"
-        }
-
-        private fun extractUniqueModules(models: List<DigraphModel>): Set<ModuleNode> {
-            return models.flatMap { listOf(it.source, it.target) }.toSet()
-        }
+    private fun extractUniqueModules(models: List<DigraphModel>): Set<ModuleNode> {
+        return models.flatMap { listOf(it.source, it.target) }.toSet()
     }
 }

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/graph/subgraph/SubgraphBuilder.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/graph/subgraph/SubgraphBuilder.kt
@@ -13,4 +13,3 @@ internal object SubgraphBuilder {
         else -> FlatSubgraphBuilder.build(digraphModels, config.showFullPath)
     }
 }
-

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/graph/subgraph/SubgraphBuilder.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/graph/subgraph/SubgraphBuilder.kt
@@ -1,0 +1,16 @@
+package dev.iurysouza.modulegraph.graph.subgraph
+
+import dev.iurysouza.modulegraph.graph.DigraphModel
+import dev.iurysouza.modulegraph.graph.MermaidCode
+import dev.iurysouza.modulegraph.model.GraphConfig
+
+internal object SubgraphBuilder {
+    internal fun build(
+        digraphModels: List<DigraphModel>,
+        config: GraphConfig,
+    ): MermaidCode = when {
+        config.nestingEnabled -> NestedSubgraphBuilder.build(digraphModels)
+        else -> FlatSubgraphBuilder.build(digraphModels, config.showFullPath)
+    }
+}
+

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/model/GraphConfig.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/model/GraphConfig.kt
@@ -74,6 +74,14 @@ data class GraphConfig(
     val strictMode: Boolean,
 
     /**
+     * Whether to enable nested subgraphs in the generated graph.
+     * When enabled, modules will be grouped into subgraphs based on their path structure.
+     * For example, modules under ":libs:feature1" and ":libs:feature2" will be nested under a ":libs" subgraph.
+     * Note: This option is ignored if [showFullPath] is true.
+     */
+    val nestingEnabled: Boolean,
+
+    /**
      * A Regex to match modules that should be used as root modules.
      * If this value is supplied,
      * the generated graph will only include dependencies (direct and transitive) of root modules.
@@ -120,19 +128,27 @@ data class GraphConfig(
          */
         var strictMode: Boolean? = null
 
-        internal fun build() = GraphConfig(
-            readmePath = readmePath,
-            heading = heading,
-            theme = theme ?: Theme.NEUTRAL,
-            orientation = orientation ?: Orientation.LEFT_TO_RIGHT,
-            linkText = linkText ?: LinkText.NONE,
-            setStyleByModuleType = setStyleByModuleType ?: false,
-            focusedModulesRegex = focusedModulesRegex,
-            excludedConfigurationsRegex = excludedConfigurationsRegex,
-            excludedModulesRegex = excludedModulesRegex,
-            rootModulesRegex = rootModulesRegex,
-            showFullPath = showFullPath ?: false,
-            strictMode = strictMode ?: false,
-        )
+        /**
+         * See [@GraphConfig.nestingEnabled]
+         */
+        var nestingEnabled: Boolean? = null
+
+        internal fun build(): GraphConfig {
+            return GraphConfig(
+                readmePath = readmePath,
+                heading = heading,
+                theme = theme ?: Theme.NEUTRAL,
+                orientation = orientation ?: Orientation.LEFT_TO_RIGHT,
+                linkText = linkText ?: LinkText.NONE,
+                setStyleByModuleType = setStyleByModuleType ?: false,
+                focusedModulesRegex = focusedModulesRegex,
+                excludedConfigurationsRegex = excludedConfigurationsRegex,
+                excludedModulesRegex = excludedModulesRegex,
+                rootModulesRegex = rootModulesRegex,
+                showFullPath = showFullPath ?: false,
+                strictMode = strictMode ?: false,
+                nestingEnabled = nestingEnabled ?: false,
+            )
+        }
     }
 }

--- a/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/ModuleGraphPluginFunctionalTest.kt
+++ b/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/ModuleGraphPluginFunctionalTest.kt
@@ -42,7 +42,7 @@ class ModuleGraphPluginFunctionalTest {
             """.trimIndent(),
         )
 
-        val appBuildFile = File(testProjectDir, "App/build.gradle.kts").apply {
+        File(testProjectDir, "App/build.gradle.kts").apply {
             parentFile.mkdirs()
             writeText(
                 """
@@ -87,6 +87,7 @@ class ModuleGraphPluginFunctionalTest {
                 }%%
 
                 graph LR
+                  :App["App"]
                   subgraph :libs
                     :libs:app-common["app-common"]
                     subgraph :crash-reporting
@@ -94,6 +95,7 @@ class ModuleGraphPluginFunctionalTest {
                       :libs:crash-reporting:firebase["firebase"]
                     end
                   end
+
                   :App --> :libs:app-common
                   :App --> :libs:crash-reporting:api
                   :App --> :libs:crash-reporting:firebase

--- a/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/ModuleGraphPluginFunctionalTest.kt
+++ b/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/ModuleGraphPluginFunctionalTest.kt
@@ -31,6 +31,78 @@ class ModuleGraphPluginFunctionalTest {
     }
 
     @Test
+    fun `when plugin is ran with nested modules it produces the expected output`() {
+        settingsFile.writeText(
+            """
+                rootProject.name = "test"
+                include(":libs:app-common")
+                include(":libs:crash-reporting:api")
+                include(":libs:crash-reporting:firebase")
+                include(":App")
+            """.trimIndent(),
+        )
+
+        val appBuildFile = File(testProjectDir, "App/build.gradle.kts").apply {
+            parentFile.mkdirs()
+            writeText(
+                """
+                    plugins {
+                        java
+                        id("$MODULEGRAPH_PACKAGE")
+                    }
+
+                    moduleGraphConfig {
+                        heading.set("### Dependency Diagram")
+                        readmePath.set("${readmeFilePath()}")
+                        nestingEnabled.set(true)
+                    }
+                    dependencies {
+                        implementation(project(":libs:app-common"))
+                        implementation(project(":libs:crash-reporting:api"))
+                        implementation(project(":libs:crash-reporting:firebase"))
+                    }
+                """.trimIndent(),
+            )
+        }
+
+        readmeFile.writeText("### Dependency Diagram")
+
+        // Run the plugin task
+        GradleRunner.create()
+            .withProjectDir(testProjectDir)
+            .withArguments("createModuleGraph")
+            .withPluginClasspath()
+            .build()
+
+        // Check if the output matches the expected result
+        val expectedOutput =
+            """
+                ### Dependency Diagram
+
+                ```mermaid
+                %%{
+                  init: {
+                    'theme': 'neutral'
+                  }
+                }%%
+
+                graph LR
+                  subgraph :libs
+                    :libs:app-common["app-common"]
+                    subgraph :crash-reporting
+                      :libs:crash-reporting:api["api"]
+                      :libs:crash-reporting:firebase["firebase"]
+                    end
+                  end
+                  :App --> :libs:app-common
+                  :App --> :libs:crash-reporting:api
+                  :App --> :libs:crash-reporting:firebase
+                ```
+            """.trimIndent()
+        assertEquals(expectedOutput, readmeFile.readText())
+    }
+
+    @Test
     fun `when plugin is ran it produces the expected output`() {
         settingsFile.writeText(
             """

--- a/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/graph/Fixtures.kt
+++ b/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/graph/Fixtures.kt
@@ -86,8 +86,7 @@ internal fun getConfig(
     showFullPath: Boolean? = null,
     strictMode: Boolean? = null,
     enableNesting: Boolean? = null,
-
-    ) =
+) =
     GraphConfig.Builder(
         readmePath = readmePath,
         heading = heading,

--- a/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/graph/Fixtures.kt
+++ b/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/graph/Fixtures.kt
@@ -85,7 +85,9 @@ internal fun getConfig(
     setStyleByModuleType: Boolean? = null,
     showFullPath: Boolean? = null,
     strictMode: Boolean? = null,
-) =
+    enableNesting: Boolean? = null,
+
+    ) =
     GraphConfig.Builder(
         readmePath = readmePath,
         heading = heading,
@@ -100,6 +102,7 @@ internal fun getConfig(
         this.setStyleByModuleType = setStyleByModuleType
         this.showFullPath = showFullPath
         this.strictMode = strictMode
+        this.enableNesting = enableNesting
     }.build()
 
 internal val liveMatchReconstructedModel = mapOf(

--- a/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/graph/Fixtures.kt
+++ b/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/graph/Fixtures.kt
@@ -85,7 +85,7 @@ internal fun getConfig(
     setStyleByModuleType: Boolean? = null,
     showFullPath: Boolean? = null,
     strictMode: Boolean? = null,
-    enableNesting: Boolean? = null,
+    nestingEnabled: Boolean? = null,
 ) =
     GraphConfig.Builder(
         readmePath = readmePath,
@@ -101,7 +101,7 @@ internal fun getConfig(
         this.setStyleByModuleType = setStyleByModuleType
         this.showFullPath = showFullPath
         this.strictMode = strictMode
-        this.enableNesting = enableNesting
+        this.nestingEnabled = nestingEnabled
     }.build()
 
 internal val liveMatchReconstructedModel = mapOf(

--- a/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/graph/NestedSubgraphTest.kt
+++ b/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/graph/NestedSubgraphTest.kt
@@ -6,7 +6,7 @@ import dev.iurysouza.modulegraph.model.GraphParseResult
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
-class NestedSubgraphLiveMatchGraphTest {
+class NestedSubgraphTest {
 
     @Test
     fun `Build digraph with nested subgraphs`() {
@@ -14,7 +14,7 @@ class NestedSubgraphLiveMatchGraphTest {
         val config = getConfig()
         val result = Mermaid.generateGraph(GraphParseResult(graphModel, config))
 
-        val nestedGraph ="""
+        val nestedGraph = """
         ```mermaid
             %%{
               init: {
@@ -60,7 +60,6 @@ class NestedSubgraphLiveMatchGraphTest {
         """.trimIndent()
         assertEquals(nestedGraph, result)
     }
-
 
     private fun nestedModuleGraph() = mapOf(
         Module(

--- a/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/graph/NestedSubgraphTest.kt
+++ b/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/graph/NestedSubgraphTest.kt
@@ -11,33 +11,42 @@ class NestedSubgraphTest {
     @Test
     fun `Build digraph with nested subgraphs`() {
         val graphModel = nestedModuleGraph()
-        val config = getConfig()
+        val config = getConfig(nestingEnabled = true)
         val result = Mermaid.generateGraph(GraphParseResult(graphModel, config))
 
         val nestedGraph = """
         ```mermaid
-            %%{
-              init: {
-                'theme': 'neutral'
-              }
-            }%%
+        %%{
+          init: {
+            'theme': 'neutral'
+          }
+        }%%
 
-            graph LR
-              subgraph :libs
-                :libs:app-common["app-common"]
-                subgraph :crash-reporting
-                  :libs:crash-reporting:api["api"]
-                  :libs:crash-reporting:firebase["firebase"]
-                end
-              end
-              :App --> :libs:app-common
-              :App --> :libs:crash-reporting:api
-              :App --> :libs:crash-reporting:firebase
-            classDef focus fill:#769566,stroke:#fff,stroke-width:2px,color:#fff;
-            class :App focus
+        graph LR
+          :App["App"]
+          subgraph :libs
+            :libs:app-common["app-common"]
+            subgraph :crash-reporting
+              :libs:crash-reporting:api["api"]
+              :libs:crash-reporting:firebase["firebase"]
+            end
+          end
+
+          :App --> :libs:app-common
+          :App --> :libs:crash-reporting:api
+          :App --> :libs:crash-reporting:firebase
         ```
         """.trimIndent()
-        val expectedMermaidCode = """
+        assertEquals(nestedGraph, result)
+    }
+
+    @Test
+    fun `Build digraph with flat subgraphs`() {
+        val graphModel = nestedModuleGraph()
+        val config = getConfig(nestingEnabled = false)
+        val result = Mermaid.generateGraph(GraphParseResult(graphModel, config))
+
+        val expectedGraph = """
         ```mermaid
         %%{
           init: {
@@ -58,7 +67,7 @@ class NestedSubgraphTest {
           :App --> :libs:crash-reporting:firebase
         ```
         """.trimIndent()
-        assertEquals(nestedGraph, result)
+        assertEquals(expectedGraph, result)
     }
 
     private fun nestedModuleGraph() = mapOf(

--- a/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/graph/NestedSubgraphTest.kt
+++ b/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/graph/NestedSubgraphTest.kt
@@ -1,0 +1,71 @@
+package dev.iurysouza.modulegraph.graph
+
+import dev.iurysouza.modulegraph.Mermaid
+import dev.iurysouza.modulegraph.gradle.Module
+import dev.iurysouza.modulegraph.model.GraphParseResult
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class NestedSubgraphLiveMatchGraphTest {
+
+    @Test
+    fun `Build digraph with nested subgraphs`() {
+        val graphModel = nestedModuleGraph()
+        val config = getConfig()
+
+        val result = Mermaid.generateGraph(GraphParseResult(graphModel, config))
+
+
+        val expectedMermaidCode = """
+        ```mermaid
+        %%{
+          init: {
+            'theme': 'neutral'
+          }
+        }%%
+
+        graph LR
+          subgraph :libs
+            :libs:app-common["app-common"]
+          end
+          subgraph :libs:crash-reporting
+            :libs:crash-reporting:api["api"]
+            :libs:crash-reporting:firebase["firebase"]
+          end
+          :App --> :libs:app-common
+          :App --> :libs:crash-reporting:api
+          :App --> :libs:crash-reporting:firebase
+        ```
+        """.trimIndent()
+        assertEquals(expectedMermaidCode, result)
+    }
+
+
+    private fun nestedModuleGraph() = mapOf(
+        Module(
+            path = ":App",
+        ) to listOf(
+            Module(
+                path = ":libs:app-common",
+                configName = "implementation",
+            ),
+            Module(
+                path = ":libs:crash-reporting:api",
+                configName = "implementation",
+            ),
+            Module(
+                path = ":libs:crash-reporting:firebase",
+                configName = "implementation",
+            ),
+        ),
+        Module(
+            path = ":libs:crash-reporting:api",
+        ) to emptyList(),
+        Module(
+            path = ":libs:crash-reporting:firebase",
+        ) to emptyList(),
+        Module(
+            path = ":libs:app-common",
+        ) to emptyList(),
+    )
+}

--- a/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/graph/NestedSubgraphTest.kt
+++ b/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/graph/NestedSubgraphTest.kt
@@ -12,10 +12,31 @@ class NestedSubgraphLiveMatchGraphTest {
     fun `Build digraph with nested subgraphs`() {
         val graphModel = nestedModuleGraph()
         val config = getConfig()
-
         val result = Mermaid.generateGraph(GraphParseResult(graphModel, config))
 
+        val nestedGraph ="""
+        ```mermaid
+            %%{
+              init: {
+                'theme': 'neutral'
+              }
+            }%%
 
+            graph LR
+              subgraph :libs
+                :libs:app-common["app-common"]
+                subgraph :crash-reporting
+                  :libs:crash-reporting:api["api"]
+                  :libs:crash-reporting:firebase["firebase"]
+                end
+              end
+              :App --> :libs:app-common
+              :App --> :libs:crash-reporting:api
+              :App --> :libs:crash-reporting:firebase
+            classDef focus fill:#769566,stroke:#fff,stroke-width:2px,color:#fff;
+            class :App focus
+        ```
+        """.trimIndent()
         val expectedMermaidCode = """
         ```mermaid
         %%{
@@ -37,7 +58,7 @@ class NestedSubgraphLiveMatchGraphTest {
           :App --> :libs:crash-reporting:firebase
         ```
         """.trimIndent()
-        assertEquals(expectedMermaidCode, result)
+        assertEquals(nestedGraph, result)
     }
 
 

--- a/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/graph/SubgraphBuilderTest.kt
+++ b/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/graph/SubgraphBuilderTest.kt
@@ -2,6 +2,7 @@ package dev.iurysouza.modulegraph.graph
 
 import dev.iurysouza.modulegraph.Orientation
 import dev.iurysouza.modulegraph.gradle.Module
+import dev.iurysouza.modulegraph.graph.subgraph.FlatSubgraphBuilder
 import dev.iurysouza.modulegraph.model.GraphParseResult
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -21,7 +22,7 @@ class SubgraphBuilderTest {
         val config = getConfig()
         val result = GraphParseResult(graphModel, config)
 
-        val subgraph = SubgraphBuilder.build(
+        val subgraph = FlatSubgraphBuilder.build(
             list = DigraphBuilder.build(result),
             showFullPath = false,
         ).value
@@ -43,7 +44,7 @@ class SubgraphBuilderTest {
         )
         val result = GraphParseResult(graphModel, config)
 
-        val subgraph = SubgraphBuilder.build(
+        val subgraph = FlatSubgraphBuilder.build(
             list = DigraphBuilder.build(result),
             showFullPath = true,
         )
@@ -60,7 +61,7 @@ class SubgraphBuilderTest {
         )
         val result = GraphParseResult(graphModel, config)
 
-        val subgraph = SubgraphBuilder.build(
+        val subgraph = FlatSubgraphBuilder.build(
             list = DigraphBuilder.build(result),
             showFullPath = false,
         )

--- a/plugin-build/settings.gradle.kts
+++ b/plugin-build/settings.gradle.kts
@@ -18,19 +18,6 @@ dependencyResolutionManagement {
     }
 }
 
-plugins {
-    `gradle-enterprise`
-}
-
-gradleEnterprise {
-    buildScan {
-        termsOfServiceUrl = "https://gradle.com/terms-of-service"
-        termsOfServiceAgree = "yes"
-        publishAlwaysIf(System.getenv("GITHUB_ACTIONS") == "true")
-        publishOnFailure()
-    }
-}
-
 rootProject.name = ("dev.iurysouza.modulegraph.plugin")
 
 include(":modulegraph")

--- a/sample/README.md
+++ b/sample/README.md
@@ -30,7 +30,6 @@ graph TB
     :sample:zeta["zeta"]
     :sample:beta["beta"]
     :sample:alpha["alpha"]
-    :sample:test["test"]
   end
   subgraph :sample:container
     :sample:container:gama["gama"]
@@ -42,7 +41,6 @@ graph TB
   :sample:alpha --> :sample:beta
   :sample:alpha --> :sample:container:gama
   :sample:alpha --> :sample:container:delta
-  :sample:alpha --> :sample:test
 
 classDef java fill:#B5661C,stroke:#fff,stroke-width:2px,color:#fff;
 class :sample:container:gama java
@@ -50,7 +48,6 @@ class :sample:zeta java
 class :sample:beta java
 class :sample:alpha java
 class :sample:container:delta java
-class :sample:test java
 
 ```
 # Graph with root: gama
@@ -63,5 +60,15 @@ class :sample:test java
 }%%
 
 graph LR
+  subgraph :sample
+    :sample:zeta["zeta"]
+    :sample:zeta["zeta"]
+    :sample:beta["beta"]
+    subgraph :container
+      :sample:container:gama["gama"]
+    end
+  end
 
+  :sample:container:gama --> :sample:zeta
+  :sample:zeta --> :sample:beta
 ```

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -53,12 +53,14 @@ moduleGraphConfig {
         readmePath = "./README.md",
         heading = "# Graph with root: gama",
     ) {
+        nestingEnabled = true
         rootModulesRegex = ".*gama.*"
     }
     graph(
         readmePath = "./SomeOtherReadme.md",
         heading = "# Graph",
     ) {
+        nestingEnabled = false
         rootModulesRegex = ".*zeta.*"
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,19 +13,6 @@ dependencyResolutionManagement {
     }
 }
 
-plugins {
-    `gradle-enterprise`
-}
-
-gradleEnterprise {
-    buildScan {
-        termsOfServiceUrl = "https://gradle.com/terms-of-service"
-        termsOfServiceAgree = "yes"
-        publishAlwaysIf(System.getenv("GITHUB_ACTIONS") == "true")
-        publishOnFailure()
-    }
-}
-
 rootProject.name = "module-graph-plugin-project"
 
 include(":sample:alpha")

--- a/version-bumper.main.kts
+++ b/version-bumper.main.kts
@@ -5,8 +5,8 @@ import java.io.IOException
 import java.util.Properties
 import kotlin.system.exitProcess
 
-val VERSION_FILE = "./plugin-build/gradle.properties"
-val README_FILE = "./README.md"
+val versionFile = "./plugin-build/gradle.properties"
+val readmeFile = "./readme.md"
 
 enum class VersionPart { MAJOR, MINOR, PATCH }
 
@@ -33,7 +33,7 @@ fun bumpVersion(part: VersionPart, release: Boolean, isSnapshot: Boolean) {
 fun getCurrentVersion(): String {
     return try {
         val properties = Properties()
-        File(VERSION_FILE).inputStream().use { properties.load(it) }
+        File(versionFile).inputStream().use { properties.load(it) }
         properties.getProperty("VERSION") ?: throw IOException("Version not found in properties file")
     } catch (e: IOException) {
         println("Version file not found!")
@@ -53,20 +53,20 @@ fun incrementVersion(currentVersion: String, part: VersionPart): String {
 
 fun updateVersionFile(newVersion: String) {
     val properties = Properties()
-    File(VERSION_FILE).inputStream().use { properties.load(it) }
+    File(versionFile).inputStream().use { properties.load(it) }
     properties.setProperty("VERSION", newVersion.removePrefix("v"))
-    File(VERSION_FILE).outputStream().use { properties.store(it, null) }
+    File(versionFile).outputStream().use { properties.store(it, null) }
     println(properties)
 }
 
 fun updateReadmeVersions(newVersion: String) {
     try {
-        val readmeContent = File(README_FILE).readText()
+        val readmeContent = File(readmeFile).readText()
         val updatedContent = readmeContent.replace(
             Regex("""dev\.iurysouza:modulegraph:\d+\.\d+\.\d+"""),
             "dev.iurysouza:modulegraph:${newVersion.removePrefix("v")}",
         )
-        File(README_FILE).writeText(updatedContent)
+        File(readmeFile).writeText(updatedContent)
         println("Updated version references in README to $newVersion")
     } catch (e: IOException) {
         println("An error occurred while updating README: ${e.message}")
@@ -77,7 +77,7 @@ fun updateReadmeVersions(newVersion: String) {
 fun commitTagAndPush(newVersion: String) {
     try {
         println("Committing changes...")
-        runCommand("git", "add", VERSION_FILE)
+        runCommand("git", "add", versionFile)
         runCommand("git", "commit", "-m", "Bump version to $newVersion")
         runCommand("git", "push")
         runCommand("git", "tag", newVersion)


### PR DESCRIPTION
## 🚀 Description

Enables a new feature, controlled by the "nestingEnabled" option, which nests subgraphs under their parent modules for a clearer, more concise dependency visualization. Solves #54 

## 📄 Motivation and Context

Makes module graphs easier to read by nesting subgraphs under their parent modules, improving clarity.


## 🧪 How Has This Been Tested?
- Added unit test for checking nested module behavior
- Verified nested subgraph behavior
- Tested compatibility with existing features

## 📦 Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.