### PR TITLE
Fix getDependecyProject method deprecation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ captures/
 .idea/jarRepositories.xml
 .idea/navEditor.xml
 !/gradle/wrapper/gradle-wrapper.jar
+.serena/
+CLAUDE.md

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/graphparser/projectquerier/GradleProjectQuerier.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/graphparser/projectquerier/GradleProjectQuerier.kt
@@ -21,7 +21,7 @@ internal class GradleProjectQuerier(private val allProjects: Set<Project>) : Pro
         return project.configurations.map { config ->
             val projectPaths = config.dependencies
                 .withType(ProjectDependency::class.java)
-                .map { subproject -> subproject.dependencyProject.path }
+                .map { subproject -> subproject.path }
             GradleProjectConfiguration(config.name, projectPaths)
         }
     }


### PR DESCRIPTION
  ## 🚀 Description
  Replaces deprecated `ProjectDependency.getDependencyProject().path` with `ProjectDependency.path` in the `GradleProjectQuerier` class. Also upgrades Gradle from 8.9 to 8.11.1 to support the new API.

  ## 📄 Motivation and Context
  Closes #63 - The `getDependencyProject()` method is deprecated and scheduled for removal in Gradle 9.0. This change eliminates the deprecation warning by using the replacement API introduced in Gradle 8.11. Users reported build failures when using Gradle 9.0.

  ## 🧪 How Has This Been Tested?
  - Ran `./gradlew test` - all unit tests pass
  - Ran `./gradlew preMerge` - all quality checks pass
  - Verified plugin functionality with sample project
  - Confirmed deprecation warnings are eliminated

  ## 📦 Types of changes
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

  ## ✅ Checklist
  - [x] My code follows the code style of this project.
  - [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
