### PR TITLE
docs: fix wrong config name from includeIndependentModules to includeIsolatedModules

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Optional settings:
     - If set, only these modules and their dependencies (direct and transitive) will be included in the graph.
     - If not set, all modules are considered root modules, which means the graph will include all modules and their dependencies.
     - This is useful when you want to focus on a specific part of your project's dependency structure.
--   **includeIndependentModules**: Whether to include modules with no connections (no dependencies and no dependants) in the graph. Default is `false`.
+-   **includeIsolatedModules**: Whether to include modules with no connections (no dependencies and no dependants) in the graph. Default is `false`.
 
 ### Multiple graphs
 


### PR DESCRIPTION

<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
<!-- Describe your changes in detail -->
Fixes wrong config name in documentation for `includeIsolatedModules` introduced in #66 

## 📄 Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The README referenced a non-existent config option `includeIndependentModules`. This update corrects it to `includeIsolatedModules` to match the actual implementation.

## 🧪 How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Verified by checking the source code and running with `includeIsolatedModules` to confirm it works as documented.


## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.