### PR TITLE
fix: harden VERSION against release-please marker leaks

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -4,6 +4,28 @@ Releases are automated with [release-please](https://github.com/googleapis/relea
 
 `plugin-build/gradle.properties` (`VERSION`) is the source of truth. README install snippets are kept in sync via release-please markers. Merging a release PR bumps the version, updates `CHANGELOG.md`, creates a `v*` tag, and publishes a GitHub Release. The `Publish Plugin to Portal` workflow then uploads to the Gradle Plugin Portal.
 
+
+
+## VERSION markers (important)
+
+`plugin-build/gradle.properties` is a Java `.properties` file. A mid-line `#` is **not** a comment; it becomes part of the value. That is how Portal publish once failed on:
+
+```properties
+VERSION=0.14.0 # x-release-please-version
+```
+
+**Always** use block markers on their own lines:
+
+```properties
+# x-release-please-start-version
+VERSION=0.14.1
+# x-release-please-end
+```
+
+Never put `x-release-please-version` (or any `#…`) on the `VERSION=` line.
+
+`validateVersionProperties` (part of `check` / `preMerge`) fails the build if the VERSION line is dirty. `sanitizePluginVersion` also strips a trailing `#…` if one slips through at publish time, then rejects anything still invalid.
+
 ## Setup (one-time)
 
 Create a fine-grained PAT with `contents:write` and `pull-requests:write` on this repo (or reuse the one used for `visual-artifact-renderer` / `clockwork`), then add it as the repository secret `RELEASE_PLEASE_TOKEN`.

--- a/plugin-build/modulegraph/build.gradle.kts
+++ b/plugin-build/modulegraph/build.gradle.kts
@@ -31,12 +31,54 @@ kotlin {
     jvmToolchain(8)
 }
 
+/** Plugin Portal version rules (must stay in sync with VersionPropertiesGuardTest). */
+fun sanitizePluginVersion(raw: String): String {
+    val stripped = raw.trim().substringBefore("#").trim()
+    require(stripped.isNotEmpty()) {
+        "VERSION is empty after sanitizing '$raw'"
+    }
+    require(' ' !in stripped && '\t' !in stripped) {
+        "VERSION must not contain whitespace: '$stripped' (from '$raw')"
+    }
+    require(stripped.length < 50) {
+        "VERSION must be under 50 characters: '$stripped'"
+    }
+    require(stripped.any { it.isDigit() }) {
+        "VERSION must include a number: '$stripped'"
+    }
+    require(stripped.matches(Regex("""^[a-zA-Z0-9.\-\[\]:+]+$"""))) {
+        "VERSION '$stripped' is not Plugin Portal-safe (from '$raw'). " +
+            "Never put release-please markers on the VERSION= line."
+    }
+    return stripped
+}
+
+fun assertCleanVersionProperties(content: String) {
+    val versionLines = content.lineSequence()
+        .map { it.trimEnd() }
+        .filter { it.trimStart().startsWith("VERSION=") }
+        .toList()
+    require(versionLines.size == 1) {
+        "Expected exactly one VERSION= line in gradle.properties, found ${versionLines.size}"
+    }
+    val line = versionLines.single()
+    require('#' !in line) {
+        "VERSION line must not contain '#': '$line'. " +
+            "Java Properties treats mid-line # as part of the value. " +
+            "Use # x-release-please-start-version / # x-release-please-end on their own lines."
+    }
+    sanitizePluginVersion(line.substringAfter("VERSION="))
+}
+
+
+val pluginVersion = sanitizePluginVersion(property("VERSION").toString())
+
 gradlePlugin {
     plugins {
         create(property("ID").toString()) {
             id = property("ID").toString()
             implementationClass = property("IMPLEMENTATION_CLASS").toString()
-            version = property("VERSION").toString()
+            version = pluginVersion
             description = property("DESCRIPTION").toString()
             displayName = property("DISPLAY_NAME").toString()
             tags.set(listOf("mermaid", "diagram"))
@@ -44,7 +86,7 @@ gradlePlugin {
         create("${property("ID")}.settings") {
             id = "${property("ID")}.settings"
             implementationClass = property("IMPLEMENTATION_CLASS_SETTINGS").toString()
-            version = property("VERSION").toString()
+            version = pluginVersion
             description = property("DESCRIPTION").toString()
             displayName = "${property("DISPLAY_NAME")} (Settings)"
             tags.set(listOf("mermaid", "diagram"))
@@ -55,6 +97,21 @@ gradlePlugin {
 gradlePlugin {
     website.set(property("WEBSITE").toString())
     vcsUrl.set(property("VCS_URL").toString())
+}
+
+
+tasks.register("validateVersionProperties") {
+    group = "verification"
+    description = "Fails if plugin-build/gradle.properties VERSION is not Plugin Portal-safe."
+    val propsFile = rootProject.file("gradle.properties")
+    inputs.file(propsFile)
+    doLast {
+        assertCleanVersionProperties(propsFile.readText())
+    }
+}
+
+tasks.named("check") {
+    dependsOn("validateVersionProperties")
 }
 
 tasks.create("setupPluginUploadFromEnvironment") {

--- a/plugin-build/modulegraph/build.gradle.kts
+++ b/plugin-build/modulegraph/build.gradle.kts
@@ -70,7 +70,6 @@ fun assertCleanVersionProperties(content: String) {
     sanitizePluginVersion(line.substringAfter("VERSION="))
 }
 
-
 val pluginVersion = sanitizePluginVersion(property("VERSION").toString())
 
 gradlePlugin {
@@ -98,7 +97,6 @@ gradlePlugin {
     website.set(property("WEBSITE").toString())
     vcsUrl.set(property("VCS_URL").toString())
 }
-
 
 tasks.register("validateVersionProperties") {
     group = "verification"

--- a/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/VersionPropertiesGuardTest.kt
+++ b/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/VersionPropertiesGuardTest.kt
@@ -1,0 +1,110 @@
+package dev.iurysouza.modulegraph
+
+import java.io.File
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Mirrors the VERSION guards in plugin-build/modulegraph/build.gradle.kts.
+ * Keep these rules identical so CI proves the Portal footgun stays closed.
+ */
+object VersionPropertiesGuard {
+    fun sanitizePluginVersion(raw: String): String {
+        val stripped = raw.trim().substringBefore("#").trim()
+        require(stripped.isNotEmpty()) {
+            "VERSION is empty after sanitizing '$raw'"
+        }
+        require(' ' !in stripped && '\t' !in stripped) {
+            "VERSION must not contain whitespace: '$stripped' (from '$raw')"
+        }
+        require(stripped.length < 50) {
+            "VERSION must be under 50 characters: '$stripped'"
+        }
+        require(stripped.any { it.isDigit() }) {
+            "VERSION must include a number: '$stripped'"
+        }
+        require(stripped.matches(Regex("""^[a-zA-Z0-9.\-\[\]:+]+$"""))) {
+            "VERSION '$stripped' is not Plugin Portal-safe (from '$raw'). " +
+                "Never put release-please markers on the VERSION= line."
+        }
+        return stripped
+    }
+
+    fun assertCleanVersionProperties(content: String) {
+        val versionLines = content.lineSequence()
+            .map { it.trimEnd() }
+            .filter { it.trimStart().startsWith("VERSION=") }
+            .toList()
+        require(versionLines.size == 1) {
+            "Expected exactly one VERSION= line in gradle.properties, found ${versionLines.size}"
+        }
+        val line = versionLines.single()
+        require('#' !in line) {
+            "VERSION line must not contain '#': '$line'. " +
+                "Java Properties treats mid-line # as part of the value. " +
+                "Use # x-release-please-start-version / # x-release-please-end on their own lines."
+        }
+        sanitizePluginVersion(line.substringAfter("VERSION="))
+    }
+}
+
+class VersionPropertiesGuardTest {
+
+    @Test
+    fun `rejects inline release-please marker on VERSION line`() {
+        val bad = """
+            GROUP=dev.iurysouza
+            VERSION=0.14.0 # x-release-please-version
+            ID=dev.iurysouza.modulegraph
+        """.trimIndent()
+
+        val error = assertThrows(IllegalArgumentException::class.java) {
+            VersionPropertiesGuard.assertCleanVersionProperties(bad)
+        }
+        assertTrue(error.message!!.contains("must not contain '#'"), error.message)
+        assertTrue(error.message!!.contains("0.14.0 # x-release-please-version"), error.message)
+    }
+
+    @Test
+    fun `accepts start-end block markers`() {
+        val good = """
+            GROUP=dev.iurysouza
+            # x-release-please-start-version
+            VERSION=0.14.0
+            # x-release-please-end
+            ID=dev.iurysouza.modulegraph
+        """.trimIndent()
+
+        VersionPropertiesGuard.assertCleanVersionProperties(good)
+    }
+
+    @Test
+    fun `sanitize strips accidental mid-line comment but file guard still fails`() {
+        assertEquals(
+            "0.14.0",
+            VersionPropertiesGuard.sanitizePluginVersion("0.14.0 # x-release-please-version"),
+        )
+        assertThrows(IllegalArgumentException::class.java) {
+            VersionPropertiesGuard.assertCleanVersionProperties(
+                "VERSION=0.14.0 # x-release-please-version\n",
+            )
+        }
+    }
+
+    @Test
+    fun `checked-in gradle dot properties stays clean`() {
+        val props = File("../gradle.properties")
+        // From test working dir (modulegraph project) this is plugin-build/gradle.properties
+        val candidates = listOf(
+            File("gradle.properties"),
+            File("../gradle.properties"),
+            File("../../plugin-build/gradle.properties"),
+        )
+        val file = candidates.firstOrNull { it.isFile }
+            ?: File(System.getProperty("user.dir"), "../gradle.properties")
+        assertTrue(file.isFile, "gradle.properties not found from ${System.getProperty("user.dir")}")
+        VersionPropertiesGuard.assertCleanVersionProperties(file.readText())
+    }
+}


### PR DESCRIPTION
## Summary

Stops the Portal publish footgun where `VERSION=0.14.0 # x-release-please-version` was treated as the whole version string (Java `.properties` does not treat mid-line `#` as a comment).

### Changes
- `sanitizePluginVersion` when wiring the Gradle plugin: trim, strip a trailing `#…`, reject whitespace / empty / non-Portal-safe values
- `validateVersionProperties` on `check` / `preMerge`: **fails** if the `VERSION=` line contains `#`
- Tests prove `VERSION=0.14.0 # x-release-please-version` is rejected, while start/end block markers are accepted
- `docs/RELEASE.md`: never put markers on the `VERSION=` line; always use `# x-release-please-start-version` / `# x-release-please-end`
- `release-please-config.json` unchanged (generic updater + block markers already compatible)

## Test plan
- [x] Unit tests for the bad inline-marker case
- [ ] CI green (`preMerge` includes the new guard)