### PR TITLE
fix: avoid overlapping outputs from projectDirectory (#72)

### DIFF
--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/CreateModuleGraphTask.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/CreateModuleGraphTask.kt
@@ -6,14 +6,16 @@ import dev.iurysouza.modulegraph.gradle.graphparser.projectquerier.SnapshotProje
 import dev.iurysouza.modulegraph.model.GraphConfig
 import dev.iurysouza.modulegraph.model.GraphParseResult
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.services.ServiceReference
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.OutputFiles
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.options.Option
 
@@ -135,9 +137,18 @@ abstract class CreateModuleGraphTask : DefaultTask() {
     @get:ServiceReference(ModuleGraphRegistry.NAME)
     internal abstract val registry: Property<ModuleGraphRegistry>
 
-    @get:OutputDirectory
+    /**
+     * Base directory used to resolve each graph config's relative [GraphConfig.readmePath].
+     * Not an output — marking it as one made Gradle treat the whole project tree as owned by
+     * this task and fail overlapping-output validation when run alongside other tasks.
+     */
+    @get:Internal
     @get:Option(option = "projectDirectory", description = "The root project directory")
     internal abstract val projectDirectory: DirectoryProperty
+
+    /** The readme files written by this task (one per resolved graph config). */
+    @get:OutputFiles
+    internal abstract val outputFiles: ConfigurableFileCollection
 
     @get:Input
     @get:Option(

--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/ModuleGraphPlugin.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/ModuleGraphPlugin.kt
@@ -75,6 +75,13 @@ open class ModuleGraphPlugin : Plugin<Project> {
                 )
             }
             task.graphConfigsResolved.set(allGraphConfigs)
+            // Declare actual outputs so Gradle can track up-to-date / CC without claiming
+            // the entire project directory (see issue #72).
+            task.outputFiles.setFrom(
+                task.graphConfigsResolved.zip(task.projectDirectory) { configs, dir ->
+                    configs.map { config -> dir.file(config.readmePath) }
+                },
+            )
         }
     }
 

--- a/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/CreateModuleGraphOverlappingOutputsFunctionalTest.kt
+++ b/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/CreateModuleGraphOverlappingOutputsFunctionalTest.kt
@@ -1,0 +1,91 @@
+package dev.iurysouza.modulegraph
+
+import java.io.File
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * Regression coverage for Gradle overlapping-output validation
+ * when createModuleGraph runs alongside other tasks (issue #72).
+ */
+@Suppress("LongMethod")
+class CreateModuleGraphOverlappingOutputsFunctionalTest {
+    @TempDir
+    lateinit var testProjectDir: File
+    private lateinit var settingsFile: File
+    private lateinit var exampleBuildFile: File
+    private lateinit var example2BuildFile: File
+    private lateinit var readmeFile: File
+
+    @BeforeEach
+    fun setup() {
+        settingsFile = File(testProjectDir, "settings.gradle.kts")
+        exampleBuildFile = File(testProjectDir, "example/build.gradle.kts")
+        example2BuildFile = File(testProjectDir, "groupFolder/example2/build.gradle.kts")
+        exampleBuildFile.parentFile.mkdirs()
+        example2BuildFile.parentFile.mkdirs()
+        readmeFile = File(testProjectDir, "README.md")
+    }
+
+    @Test
+    fun `createModuleGraph can run alongside other tasks without overlapping output validation`() {
+        settingsFile.writeText(
+            """
+                rootProject.name = "test"
+                include(":example")
+                include(":groupFolder:example2")
+            """.trimIndent(),
+        )
+
+        exampleBuildFile.writeText(
+            """
+                plugins {
+                    java
+                    id("$MODULEGRAPH_PACKAGE")
+                }
+
+                moduleGraphConfig {
+                    heading.set("### Dependency Diagram")
+                    readmePath.set("${readmeFilePath()}")
+                }
+                dependencies {
+                    implementation(project(":groupFolder:example2"))
+                }
+            """.trimIndent(),
+        )
+        example2BuildFile.writeText(
+            """
+                plugins {
+                    java
+                }
+            """.trimIndent(),
+        )
+        readmeFile.writeText("### Dependency Diagram")
+
+        // Running createModuleGraph with another task that writes under build/
+        // used to fail Gradle overlapping-output validation when projectDirectory
+        // was wrongly declared as @OutputDirectory (issue #72).
+        val result = GradleRunner.create()
+            .withProjectDir(testProjectDir)
+            .withArguments("test", "createModuleGraph", "--stacktrace")
+            .withPluginClasspath()
+            .build()
+
+        assertTrue(result.output.contains("BUILD SUCCESSFUL") || result.tasks.isNotEmpty())
+        assertTrue(readmeFile.readText().contains(":example --> :groupFolder:example2"))
+        assertFalse(
+            result.output.contains("implicit dependency") ||
+                result.output.contains("overlapping output"),
+            result.output,
+        )
+    }
+
+    /**
+     * This is for Windows compatibility, as the path is used in the build file
+     */
+    private fun readmeFilePath() = readmeFile.absolutePath.replace("\\", "\\\\")
+}

--- a/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/ModuleGraphPluginFunctionalTest.kt
+++ b/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/ModuleGraphPluginFunctionalTest.kt
@@ -652,59 +652,6 @@ class ModuleGraphPluginFunctionalTest {
         }
     }
 
-    @Test
-    fun `createModuleGraph can run alongside other tasks without overlapping output validation`() {
-        settingsFile.writeText(
-            """
-                rootProject.name = "test"
-                include(":example")
-                include(":groupFolder:example2")
-            """.trimIndent(),
-        )
-
-        exampleBuildFile.writeText(
-            """
-                plugins {
-                    java
-                    id("$MODULEGRAPH_PACKAGE")
-                }
-
-                moduleGraphConfig {
-                    heading.set("### Dependency Diagram")
-                    readmePath.set("${readmeFilePath()}")
-                }
-                dependencies {
-                    implementation(project(":groupFolder:example2"))
-                }
-            """.trimIndent(),
-        )
-        example2BuildFile.writeText(
-            """
-                plugins {
-                    java
-                }
-            """.trimIndent(),
-        )
-        readmeFile.writeText("### Dependency Diagram")
-
-        // Running createModuleGraph with another task that writes under build/
-        // used to fail Gradle overlapping-output validation when projectDirectory
-        // was wrongly declared as @OutputDirectory (issue #72).
-        val result = GradleRunner.create()
-            .withProjectDir(testProjectDir)
-            .withArguments("test", "createModuleGraph", "--stacktrace")
-            .withPluginClasspath()
-            .build()
-
-        assertTrue(result.output.contains("BUILD SUCCESSFUL") || result.tasks.isNotEmpty())
-        assertTrue(readmeFile.readText().contains(":example --> :groupFolder:example2"))
-        assertFalse(
-            result.output.contains("implicit dependency") ||
-                result.output.contains("overlapping output"),
-            result.output,
-        )
-    }
-
     /**
      * This is for Windows compatibility, as the path is used in the build file
      */

--- a/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/ModuleGraphPluginFunctionalTest.kt
+++ b/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/ModuleGraphPluginFunctionalTest.kt
@@ -652,6 +652,59 @@ class ModuleGraphPluginFunctionalTest {
         }
     }
 
+    @Test
+    fun `createModuleGraph can run alongside other tasks without overlapping output validation`() {
+        settingsFile.writeText(
+            """
+                rootProject.name = "test"
+                include(":example")
+                include(":groupFolder:example2")
+            """.trimIndent(),
+        )
+
+        exampleBuildFile.writeText(
+            """
+                plugins {
+                    java
+                    id("$MODULEGRAPH_PACKAGE")
+                }
+
+                moduleGraphConfig {
+                    heading.set("### Dependency Diagram")
+                    readmePath.set("${readmeFilePath()}")
+                }
+                dependencies {
+                    implementation(project(":groupFolder:example2"))
+                }
+            """.trimIndent(),
+        )
+        example2BuildFile.writeText(
+            """
+                plugins {
+                    java
+                }
+            """.trimIndent(),
+        )
+        readmeFile.writeText("### Dependency Diagram")
+
+        // Running createModuleGraph with another task that writes under build/
+        // used to fail Gradle overlapping-output validation when projectDirectory
+        // was wrongly declared as @OutputDirectory (issue #72).
+        val result = GradleRunner.create()
+            .withProjectDir(testProjectDir)
+            .withArguments("test", "createModuleGraph", "--stacktrace")
+            .withPluginClasspath()
+            .build()
+
+        assertTrue(result.output.contains("BUILD SUCCESSFUL") || result.tasks.isNotEmpty())
+        assertTrue(readmeFile.readText().contains(":example --> :groupFolder:example2"))
+        assertFalse(
+            result.output.contains("implicit dependency") ||
+                result.output.contains("overlapping output"),
+            result.output,
+        )
+    }
+
     /**
      * This is for Windows compatibility, as the path is used in the build file
      */

--- a/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/ModuleGraphPluginTest.kt
+++ b/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/ModuleGraphPluginTest.kt
@@ -4,7 +4,9 @@ import dev.iurysouza.modulegraph.gradle.CreateModuleGraphTask
 import dev.iurysouza.modulegraph.gradle.ModuleGraphExtension
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class ModuleGraphPluginTest {
@@ -59,5 +61,28 @@ class ModuleGraphPluginTest {
         assertEquals("project", task.excludedModulesRegex.get())
         assertEquals(".*", task.rootModulesRegex.get())
         assertEquals(true, task.includeIsolatedModules.get())
+    }
+
+    @Test
+    fun `createModuleGraph declares readme files as outputs not the project directory`() {
+        val project = ProjectBuilder.builder().build()
+        project.pluginManager.apply(pluginId)
+        val readmeRelPath = "docs/MODULE_GRAPH.md"
+        (project.extensions.getByName(pluginExtension) as ModuleGraphExtension).apply {
+            readmePath.set(readmeRelPath)
+            heading.set("# Module Graph")
+        }
+
+        val task = project.tasks.getByName("createModuleGraph") as CreateModuleGraphTask
+        val declaredOutputs = task.outputs.files.files
+
+        assertTrue(
+            declaredOutputs.any { it == project.projectDir.resolve(readmeRelPath) },
+            "Expected readme path among outputs, got: $declaredOutputs",
+        )
+        assertFalse(
+            declaredOutputs.contains(project.projectDir),
+            "projectDirectory must not be declared as an output",
+        )
     }
 }


### PR DESCRIPTION
## Summary
`CreateModuleGraphTask.projectDirectory` was `@OutputDirectory` pointing at the project root, so running `createModuleGraph` with other tasks failed Gradle overlapping-output validation.

- Mark `projectDirectory` as `@Internal`
- Declare real outputs via `@OutputFiles` resolved from each graph config's `readmePath`
- Keep up-to-date / configuration-cache behavior

Fixes #72

## Tests
- `./gradlew :modulegraph:test` (pass)
- Includes unit test that outputs are readme files, not project dir
- Includes functional regression: `test createModuleGraph` together