### PR TITLE
fix: skip primary graph for graph-only configs (#70)

### DIFF
--- a/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/ModuleGraphPlugin.kt
+++ b/plugin-build/modulegraph/src/main/kotlin/dev/iurysouza/modulegraph/gradle/ModuleGraphPlugin.kt
@@ -80,11 +80,11 @@ open class ModuleGraphPlugin : Plugin<Project> {
 
     /** @return the primary graph config, or null if the primary config is not provided */
     private fun getPrimaryGraphConfig(task: CreateModuleGraphTask): GraphConfig? {
+        // Read raw task properties first — defaults for readmePath/heading must not be applied
+        // before the hasPrimaryConfig check, or graph-only setups always emit a primary graph
+        // into README.md (issue #70).
         val readmePath = task.readmePath.orNull
-            ?: task.project.rootDir.resolve("README.md").absolutePath
-
-        val heading = task.heading.orNull ?: "# Module Graph"
-
+        val heading = task.heading.orNull
         val theme = task.theme.orNull
         val orientation = task.orientation.orNull
         val focusedModulesRegex = task.focusedModulesRegex.orNull
@@ -125,8 +125,9 @@ open class ModuleGraphPlugin : Plugin<Project> {
         if (!hasPrimaryConfig) return null
 
         return GraphConfig.Builder(
-            readmePath = readmePath,
-            heading = heading,
+            readmePath = readmePath
+                ?: task.project.rootDir.resolve("README.md").absolutePath,
+            heading = heading ?: "# Module Graph",
         ).apply {
             this.theme = theme
             this.orientation = orientation

--- a/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/GraphOnlyConfigFunctionalTest.kt
+++ b/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/GraphOnlyConfigFunctionalTest.kt
@@ -1,0 +1,90 @@
+package dev.iurysouza.modulegraph
+
+import java.io.File
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * Regression coverage for graph-only configs that must not write
+ * the primary README Module Graph section (issue #70).
+ */
+@Suppress("LongMethod")
+class GraphOnlyConfigFunctionalTest {
+    @TempDir
+    lateinit var testProjectDir: File
+    private lateinit var settingsFile: File
+    private lateinit var exampleBuildFile: File
+    private lateinit var example2BuildFile: File
+    private lateinit var readmeFile: File
+
+    @BeforeEach
+    fun setup() {
+        settingsFile = File(testProjectDir, "settings.gradle.kts")
+        exampleBuildFile = File(testProjectDir, "example/build.gradle.kts")
+        example2BuildFile = File(testProjectDir, "groupFolder/example2/build.gradle.kts")
+        exampleBuildFile.parentFile.mkdirs()
+        example2BuildFile.parentFile.mkdirs()
+        readmeFile = File(testProjectDir, "README.md")
+    }
+
+    @Test
+    fun `graph-only config does not write primary README Module Graph section`() {
+        settingsFile.writeText(
+            """
+                rootProject.name = "test"
+                include(":example")
+                include(":groupFolder:example2")
+            """.trimIndent(),
+        )
+
+        val customReadme = File(testProjectDir, "docs/MODULE_GRAPHS.md")
+        customReadme.parentFile.mkdirs()
+        customReadme.writeText("## My Custom Graph")
+        val customPath = customReadme.absolutePath.replace("\\", "\\\\")
+        val rootReadmeOriginal = "# Untouched Root Readme\n"
+        readmeFile.writeText(rootReadmeOriginal)
+
+        exampleBuildFile.writeText(
+            """
+                plugins {
+                    java
+                    id("$MODULEGRAPH_PACKAGE")
+                }
+
+                moduleGraphConfig {
+                    graph(
+                        readmePath = "$customPath",
+                        heading = "## My Custom Graph",
+                    ) {
+                        orientation = $MODULEGRAPH_PACKAGE.Orientation.LEFT_TO_RIGHT
+                    }
+                }
+                dependencies {
+                    implementation(project(":groupFolder:example2"))
+                }
+            """.trimIndent(),
+        )
+        example2BuildFile.writeText(
+            """
+                plugins {
+                    java
+                }
+            """.trimIndent(),
+        )
+
+        GradleRunner.create()
+            .withProjectDir(testProjectDir)
+            .withArguments("createModuleGraph")
+            .withPluginClasspath()
+            .build()
+
+        assertEquals(rootReadmeOriginal, readmeFile.readText())
+        assertTrue(customReadme.readText().contains(":example --> :groupFolder:example2"))
+        assertFalse(readmeFile.readText().contains("# Module Graph"))
+    }
+}

--- a/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/ModuleGraphPluginFunctionalTest.kt
+++ b/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/ModuleGraphPluginFunctionalTest.kt
@@ -652,62 +652,6 @@ class ModuleGraphPluginFunctionalTest {
         }
     }
 
-    @Test
-    fun `graph-only config does not write primary README Module Graph section`() {
-        settingsFile.writeText(
-            """
-                rootProject.name = "test"
-                include(":example")
-                include(":groupFolder:example2")
-            """.trimIndent(),
-        )
-
-        val customReadme = File(testProjectDir, "docs/MODULE_GRAPHS.md")
-        customReadme.parentFile.mkdirs()
-        customReadme.writeText("## My Custom Graph")
-        val customPath = customReadme.absolutePath.replace("\\", "\\\\")
-        val rootReadmeOriginal = "# Untouched Root Readme\n"
-        readmeFile.writeText(rootReadmeOriginal)
-
-        exampleBuildFile.writeText(
-            """
-                plugins {
-                    java
-                    id("$MODULEGRAPH_PACKAGE")
-                }
-
-                moduleGraphConfig {
-                    graph(
-                        readmePath = "$customPath",
-                        heading = "## My Custom Graph",
-                    ) {
-                        orientation = $MODULEGRAPH_PACKAGE.Orientation.LEFT_TO_RIGHT
-                    }
-                }
-                dependencies {
-                    implementation(project(":groupFolder:example2"))
-                }
-            """.trimIndent(),
-        )
-        example2BuildFile.writeText(
-            """
-                plugins {
-                    java
-                }
-            """.trimIndent(),
-        )
-
-        GradleRunner.create()
-            .withProjectDir(testProjectDir)
-            .withArguments("createModuleGraph")
-            .withPluginClasspath()
-            .build()
-
-        assertEquals(rootReadmeOriginal, readmeFile.readText())
-        assertTrue(customReadme.readText().contains(":example --> :groupFolder:example2"))
-        assertFalse(readmeFile.readText().contains("# Module Graph"))
-    }
-
     /**
      * This is for Windows compatibility, as the path is used in the build file
      */

--- a/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/ModuleGraphPluginFunctionalTest.kt
+++ b/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/ModuleGraphPluginFunctionalTest.kt
@@ -652,6 +652,62 @@ class ModuleGraphPluginFunctionalTest {
         }
     }
 
+    @Test
+    fun `graph-only config does not write primary README Module Graph section`() {
+        settingsFile.writeText(
+            """
+                rootProject.name = "test"
+                include(":example")
+                include(":groupFolder:example2")
+            """.trimIndent(),
+        )
+
+        val customReadme = File(testProjectDir, "docs/MODULE_GRAPHS.md")
+        customReadme.parentFile.mkdirs()
+        customReadme.writeText("## My Custom Graph")
+        val customPath = customReadme.absolutePath.replace("\\", "\\\\")
+        val rootReadmeOriginal = "# Untouched Root Readme\n"
+        readmeFile.writeText(rootReadmeOriginal)
+
+        exampleBuildFile.writeText(
+            """
+                plugins {
+                    java
+                    id("$MODULEGRAPH_PACKAGE")
+                }
+
+                moduleGraphConfig {
+                    graph(
+                        readmePath = "$customPath",
+                        heading = "## My Custom Graph",
+                    ) {
+                        orientation = $MODULEGRAPH_PACKAGE.Orientation.LEFT_TO_RIGHT
+                    }
+                }
+                dependencies {
+                    implementation(project(":groupFolder:example2"))
+                }
+            """.trimIndent(),
+        )
+        example2BuildFile.writeText(
+            """
+                plugins {
+                    java
+                }
+            """.trimIndent(),
+        )
+
+        GradleRunner.create()
+            .withProjectDir(testProjectDir)
+            .withArguments("createModuleGraph")
+            .withPluginClasspath()
+            .build()
+
+        assertEquals(rootReadmeOriginal, readmeFile.readText())
+        assertTrue(customReadme.readText().contains(":example --> :groupFolder:example2"))
+        assertFalse(readmeFile.readText().contains("# Module Graph"))
+    }
+
     /**
      * This is for Windows compatibility, as the path is used in the build file
      */

--- a/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/ModuleGraphPluginTest.kt
+++ b/plugin-build/modulegraph/src/test/java/dev/iurysouza/modulegraph/ModuleGraphPluginTest.kt
@@ -5,6 +5,7 @@ import dev.iurysouza.modulegraph.gradle.ModuleGraphExtension
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class ModuleGraphPluginTest {
@@ -23,7 +24,28 @@ class ModuleGraphPluginTest {
     fun `plugin is correctly applied to the project with minimal valid graph config`() {
         val project = ProjectBuilder.builder().build()
         project.pluginManager.apply(pluginId)
+        (project.extensions.getByName(pluginExtension) as ModuleGraphExtension).apply {
+            readmePath.set("${project.projectDir}/README.md")
+            heading.set("# Module Graph")
+        }
         assert(project.tasks.getByName("createModuleGraph") is CreateModuleGraphTask)
+    }
+
+    @Test
+    fun `graph-only config does not resolve a primary graph`() {
+        val project = ProjectBuilder.builder().build()
+        project.pluginManager.apply(pluginId)
+        (project.extensions.getByName(pluginExtension) as ModuleGraphExtension).apply {
+            graph(
+                readmePath = "${project.projectDir}/docs/GRAPH.md",
+                heading = "## Custom Graph",
+            )
+        }
+        val task = project.tasks.getByName("createModuleGraph") as CreateModuleGraphTask
+        val configs = task.graphConfigsResolved.get()
+        assertEquals(1, configs.size)
+        assertEquals("## Custom Graph", configs.single().heading)
+        assertTrue(configs.single().readmePath.endsWith("docs/GRAPH.md"))
     }
 
     @Test


### PR DESCRIPTION
## Summary
`getPrimaryGraphConfig()` applied default `readmePath`/`heading` before the `hasPrimaryConfig` check, so graph-only setups always also wrote root `README.md` under `# Module Graph`.

- Check raw task properties before applying defaults
- Match README: graph-only config should not touch primary README

Fixes #70

## Tests
- `./gradlew :modulegraph:test` (pass)
- Unit: graph-only config resolves a single non-primary graph
- Functional: root README unchanged when only `graph { }` is configured